### PR TITLE
Embedded metadata

### DIFF
--- a/src/SnapDB/Snap/Services/Configuration/AdvancedServerDatabaseConfig.cs
+++ b/src/SnapDB/Snap/Services/Configuration/AdvancedServerDatabaseConfig.cs
@@ -186,6 +186,11 @@ public class AdvancedServerDatabaseConfig<TKey, TValue> : IToServerDatabaseSetti
     /// </remarks>
     public long TargetFileSize { get; set; }
 
+    /// <summary>
+    /// Gets or sets the metadata to be written to the archive.
+    /// </summary>
+    public byte[]? Metadata { get; set; }
+
     #endregion
 
     #region [ Methods ]
@@ -218,6 +223,7 @@ public class AdvancedServerDatabaseConfig<TKey, TValue> : IToServerDatabaseSetti
         settings.FirstStageWriter.RolloverInterval = DiskFlushInterval; // 10 seconds
         settings.FirstStageWriter.EncodingMethod = ArchiveEncodingMethod;
         settings.FirstStageWriter.FinalSettings.ConfigureOnDisk(new[] { m_mainPath }, SI2.Giga, ArchiveDirectoryMethod.TopDirectoryOnly, ArchiveEncodingMethod, "stage1", intermediateFilePendingExtension, intermediateFileFinalExtension, FileFlags.Stage1, FileFlags.IntermediateFile);
+        settings.FirstStageWriter.FinalSettings.Metadata = Metadata;
 
         for (int stage = 2; stage <= StagingCount; stage++)
         {
@@ -230,6 +236,8 @@ public class AdvancedServerDatabaseConfig<TKey, TValue> : IToServerDatabaseSetti
             else
                 // Final staging file
                 rollover.ArchiveSettings.ConfigureOnDisk(finalPaths, DesiredRemainingSpace, DirectoryMethod, ArchiveEncodingMethod, DatabaseName.ToNonNullNorEmptyString("stage" + stage).RemoveInvalidFileNameCharacters(), finalFilePendingExtension, finalFileFinalExtension, FileFlags.GetStage(stage));
+
+            rollover.ArchiveSettings.Metadata = Metadata;
 
             rollover.LogPath = m_mainPath;
             rollover.ExecuteTimer = 1000;

--- a/src/SnapDB/Snap/Services/Writer/CombineFiles.cs
+++ b/src/SnapDB/Snap/Services/Writer/CombineFiles.cs
@@ -109,15 +109,15 @@ public class CombineFiles<TKey, TValue> : DisposableLoggingClassBase where TKey 
 
     private void OnExecute(object sender, EventArgs<ScheduledTaskRunningReason> e)
     {
-        //The worker can be disposed either via the Stop() method or 
-        //the Dispose() method.  If via the dispose method, then
-        //don't do any cleanup.
+        // The worker can be disposed either via the Stop() method or 
+        // the Dispose() method.  If via the dispose method, then
+        // don't do any cleanup.
         if (m_disposed && e.Argument == ScheduledTaskRunningReason.Disposing)
             return;
 
-        //go ahead and schedule the next rollover since nothing
-        //will happen until this function exits anyway.
-        //if the task is disposing, the following line does nothing.
+        // go ahead and schedule the next rollover since nothing
+        // will happen until this function exits anyway.
+        // if the task is disposing, the following line does nothing.
         m_rolloverTask.Start(m_settings.ExecuteTimer);
 
         lock (m_syncRoot)

--- a/src/SnapDB/Snap/Services/Writer/FirstStageWriter.cs
+++ b/src/SnapDB/Snap/Services/Writer/FirstStageWriter.cs
@@ -312,9 +312,9 @@ public class FirstStageWriter<TKey, TValue> : DisposableLoggingClassBase where T
 
     private void RolloverTask_Running(object? sender, EventArgs<ScheduledTaskRunningReason> e)
     {
-        //The worker can be disposed either via the Stop() method or 
-        //the Dispose() method.  If via the dispose method, then
-        //don't do any cleanup.
+        // The worker can be disposed either via the Stop() method or 
+        // the Dispose() method.  If via the dispose method, then
+        // don't do any cleanup.
         if (m_disposed && e.Argument == ScheduledTaskRunningReason.Disposing)
         {
             Log.Publish(MessageLevel.Info, "Rollover thread is Disposing");

--- a/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializer.cs
+++ b/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializer.cs
@@ -103,7 +103,7 @@ public class SimplifiedArchiveInitializer<TKey, TValue> where TKey : SnapTypeBas
         string pendingFile = CreateArchiveName(GetPathWithEnoughSpace(estimatedSize), startKey, endKey);
         string finalFile = Path.ChangeExtension(pendingFile, settings.FinalExtension);
 
-        SortedTreeFileSimpleWriter<TKey, TValue>.Create(pendingFile, finalFile, 4096, archiveIdCallback, settings.EncodingMethod, data, settings.Flags.ToArray());
+        SortedTreeFileSimpleWriter<TKey, TValue>.CreateWithMetadata(pendingFile, finalFile, 4096, archiveIdCallback, settings.EncodingMethod, data, settings.Metadata, settings.Flags.ToArray());
 
         return SortedTreeFile.OpenFile(finalFile, true).OpenTable<TKey, TValue>();
     }

--- a/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializerSettings.cs
+++ b/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializerSettings.cs
@@ -172,6 +172,11 @@ public class SimplifiedArchiveInitializerSettings : SettingsBase<SimplifiedArchi
     /// </summary>
     public ImmutableList<string> WritePath { get; private set; }
 
+    /// <summary>
+    /// Gets or sets the metadata to be written to the archive.
+    /// </summary>
+    public byte[]? Metadata { get; set; }
+
     #endregion
 
     #region [ Methods ]

--- a/src/UnitTests/SortedTreeStore/Storage/SortedTreeFileSimpleWriterTest.cs
+++ b/src/UnitTests/SortedTreeStore/Storage/SortedTreeFileSimpleWriterTest.cs
@@ -190,6 +190,7 @@ public class SortedTreeFileSimpleWriterTest
         for (int x = 0; x < pointCount; x++)
         {
             key.PointID = (ulong)x;
+            value.Value1 = (ulong)x * 2;
             points.TryEnqueue(key, value);
         }
 
@@ -223,6 +224,10 @@ public class SortedTreeFileSimpleWriterTest
             {
                 if (key.PointID != (ulong)cnt)
                     throw new Exception();
+
+                if (value.Value1 != (ulong)cnt * 2)
+                    throw new Exception();
+
                 cnt++;
             }
 


### PR DESCRIPTION
This is an initial minor set of code changes to allow for embedded metadata.

Technically, from OH, all we will need to do is assign any metadata, converted to a byte array (could be compressed), and assign to property of `AdvancedServerDatabaseConfig` (used by `HistorianServerDatabaseConfig` in OH, will likely need a `Metadata` property there).