### PR TITLE
This Creates an ACL implementation for Seek / Match filters

### DIFF
--- a/src/SnapDB/Security/Authentication/IntegratedSecurityUserCredential.cs
+++ b/src/SnapDB/Security/Authentication/IntegratedSecurityUserCredential.cs
@@ -38,8 +38,11 @@ public class IntegratedSecurityUserCredential
     #region [ Members ]
 
     /// <summary>
-    /// The security identifier for the username
+    /// The security identifier (SID) for the username.
     /// </summary>
+    /// <remarks>
+    /// This value is automatically looked by username for the target OS.
+    /// </remarks>
     public string UserId;
 
     /// <summary>

--- a/src/SnapDB/Security/SecureStreamServer.cs
+++ b/src/SnapDB/Security/SecureStreamServer.cs
@@ -131,6 +131,15 @@ public class SecureStreamServer<T> : DisposableLoggingClassBase where T : IUserT
 
     #endregion
 
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets all authenticated users.
+    /// </summary>
+    public IntegratedSecurityUserCredentials Users => m_integrated.Users;
+
+    #endregion
+
     #region [ Methods ]
 
     /// <summary>

--- a/src/SnapDB/Snap/Filters/AccessControlSeekPosition.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlSeekPosition.cs
@@ -1,5 +1,5 @@
 ﻿//******************************************************************************************************
-//  AccessControlledMatchFilter.cs - Gbtc
+//  AccessControlSeekPosition.cs - Gbtc
 //
 //  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
 //
@@ -21,31 +21,19 @@
 //
 //******************************************************************************************************
 
-using SnapDB.IO;
-
 namespace SnapDB.Snap.Filters;
 
-// Wrapper around any MatchFilterBase to apply access control to the filter
-internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey, TValue>
+/// <summary>
+/// Enumeration of seek positions for any access control seek filter.
+/// </summary>
+public enum AccessControlSeekPosition
 {
-    private readonly MatchFilterBase<TKey, TValue> m_matchFilter;
-    private readonly Func<TKey, TValue, bool> m_accessControlFilter;
-
-    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, Func<TKey, TValue, bool> accessControlFilter)
-    {
-        m_matchFilter = matchFilter;
-        m_accessControlFilter = accessControlFilter;
-    }
-
-    public override Guid FilterType => m_matchFilter.FilterType;
-
-    public override void Save(BinaryStreamBase stream)
-    {
-        m_matchFilter.Save(stream);
-    }
-
-    public override bool Contains(TKey key, TValue value)
-    {
-        return m_accessControlFilter(key, value) && m_matchFilter.Contains(key, value);
-    }
+    /// <summary>
+    /// Access control check is for key at start of seek.
+    /// </summary>
+    Start,
+    /// <summary>
+    /// Access control check is for key at end of seek.
+    /// </summary>
+    End
 }

--- a/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
@@ -30,10 +30,10 @@ namespace SnapDB.Snap.Filters;
 internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey, TValue>
 {
     private readonly MatchFilterBase<TKey, TValue> m_matchFilter;
-    private readonly Func<IntegratedSecurityUserCredential, TKey, TValue, bool> m_accessControlFilter;
+    private readonly Func<string, TKey, TValue, bool> m_accessControlFilter;
     private readonly IntegratedSecurityUserCredential m_user;
 
-    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, IntegratedSecurityUserCredential user, Func<IntegratedSecurityUserCredential, TKey, TValue, bool> accessControlFilter)
+    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, IntegratedSecurityUserCredential user, Func<string, TKey, TValue, bool> accessControlFilter)
     {
         m_matchFilter = matchFilter;
         m_user = user;
@@ -49,6 +49,6 @@ internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey,
 
     public override bool Contains(TKey key, TValue value)
     {
-        return m_accessControlFilter(m_user, key, value) && m_matchFilter.Contains(key, value);
+        return m_accessControlFilter(m_user.UserId, key, value) && m_matchFilter.Contains(key, value);
     }
 }

--- a/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
@@ -1,0 +1,51 @@
+﻿//******************************************************************************************************
+//  AccessControlledMatchFilter.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  10/30/2023 - J. Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using SnapDB.IO;
+
+namespace SnapDB.Snap.Filters;
+
+// Wrapper around any MatchFilterBase to apply access control to the filter
+internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey, TValue>
+{
+    private readonly MatchFilterBase<TKey, TValue> m_matchFilter;
+    private readonly Func<TKey, TValue, bool> m_aclFilter;
+
+    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, Func<TKey, TValue, bool> aclFilter)
+    {
+        m_matchFilter = matchFilter;
+        m_aclFilter = aclFilter;
+    }
+
+    public override Guid FilterType => m_matchFilter.FilterType;
+
+    public override void Save(BinaryStreamBase stream)
+    {
+        m_matchFilter.Save(stream);
+    }
+
+    public override bool Contains(TKey key, TValue value)
+    {
+        return m_aclFilter(key, value) && m_matchFilter.Contains(key, value);
+    }
+}

--- a/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
@@ -30,14 +30,14 @@ namespace SnapDB.Snap.Filters;
 internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey, TValue>
 {
     private readonly MatchFilterBase<TKey, TValue> m_matchFilter;
-    private readonly Func<string, TKey, TValue, bool> m_accessControlFilter;
+    private readonly Func<string, TKey, TValue, bool> m_userCanMatch;
     private readonly IntegratedSecurityUserCredential m_user;
 
-    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, IntegratedSecurityUserCredential user, Func<string, TKey, TValue, bool> accessControlFilter)
+    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, IntegratedSecurityUserCredential user, Func<string, TKey, TValue, bool> userCanMatch)
     {
         m_matchFilter = matchFilter;
         m_user = user;
-        m_accessControlFilter = accessControlFilter;
+        m_userCanMatch = userCanMatch;
     }
 
     public override Guid FilterType => m_matchFilter.FilterType;
@@ -49,6 +49,6 @@ internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey,
 
     public override bool Contains(TKey key, TValue value)
     {
-        return m_accessControlFilter(m_user.UserId, key, value) && m_matchFilter.Contains(key, value);
+        return m_userCanMatch(m_user.UserId, key, value) && m_matchFilter.Contains(key, value);
     }
 }

--- a/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
@@ -27,7 +27,7 @@ using SnapDB.Security.Authentication;
 namespace SnapDB.Snap.Filters;
 
 // Wrapper around any MatchFilterBase to apply access control to the filter
-internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey, TValue>
+internal sealed class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey, TValue>
 {
     private readonly MatchFilterBase<TKey, TValue> m_matchFilter;
     private readonly Func<string, TKey, TValue, bool> m_userCanMatch;

--- a/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledMatchFilter.cs
@@ -22,6 +22,7 @@
 //******************************************************************************************************
 
 using SnapDB.IO;
+using SnapDB.Security.Authentication;
 
 namespace SnapDB.Snap.Filters;
 
@@ -29,11 +30,13 @@ namespace SnapDB.Snap.Filters;
 internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey, TValue>
 {
     private readonly MatchFilterBase<TKey, TValue> m_matchFilter;
-    private readonly Func<TKey, TValue, bool> m_accessControlFilter;
+    private readonly Func<IntegratedSecurityUserCredential, TKey, TValue, bool> m_accessControlFilter;
+    private readonly IntegratedSecurityUserCredential m_user;
 
-    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, Func<TKey, TValue, bool> accessControlFilter)
+    public AccessControlledMatchFilter(MatchFilterBase<TKey, TValue> matchFilter, IntegratedSecurityUserCredential user, Func<IntegratedSecurityUserCredential, TKey, TValue, bool> accessControlFilter)
     {
         m_matchFilter = matchFilter;
+        m_user = user;
         m_accessControlFilter = accessControlFilter;
     }
 
@@ -46,6 +49,6 @@ internal class AccessControlledMatchFilter<TKey, TValue> : MatchFilterBase<TKey,
 
     public override bool Contains(TKey key, TValue value)
     {
-        return m_accessControlFilter(key, value) && m_matchFilter.Contains(key, value);
+        return m_accessControlFilter(m_user, key, value) && m_matchFilter.Contains(key, value);
     }
 }

--- a/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
@@ -40,7 +40,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey>
     /// <summary>
     /// the end of the frame to search [Inclusive]
     /// </summary>
-    public TKey EndOfFrame
+    public new TKey EndOfFrame
     {
         get => m_seekFilter.EndOfFrame; 
         protected internal set => m_seekFilter.EndOfFrame = m_aclFilter(value, false);
@@ -49,7 +49,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey>
     /// <summary>
     /// the end of the entire range to search [Inclusive]
     /// </summary>
-    public TKey EndOfRange
+    public new TKey EndOfRange
 
     {
         get => m_seekFilter.EndOfRange; 
@@ -59,7 +59,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey>
     /// <summary>
     /// the start of the frame to search [Inclusive]
     /// </summary>
-    public TKey StartOfFrame
+    public new TKey StartOfFrame
     {
         get => m_seekFilter.StartOfFrame; 
         protected internal set => m_seekFilter.StartOfFrame = m_aclFilter(value, true);
@@ -68,7 +68,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey>
     /// <summary>
     /// the start of the entire range to search [Inclusive]
     /// </summary>
-    public TKey StartOfRange
+    public new TKey StartOfRange
     {
         get => m_seekFilter.StartOfRange; 
         protected internal set => m_seekFilter.StartOfRange = m_aclFilter(value, true);

--- a/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
@@ -22,6 +22,7 @@
 //******************************************************************************************************
 
 using SnapDB.IO;
+using SnapDB.Security.Authentication;
 using static SnapDB.Snap.Filters.AccessControlSeekPosition;
 
 namespace SnapDB.Snap.Filters;
@@ -30,11 +31,13 @@ namespace SnapDB.Snap.Filters;
 internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKey : SnapTypeBase<TKey>, new()
 {
     private readonly SeekFilterBase<TKey> m_seekFilter;
-    private readonly Func<TKey, AccessControlSeekPosition, bool> m_accessControlFilter;
+    private readonly Func<IntegratedSecurityUserCredential, TKey, AccessControlSeekPosition, bool> m_accessControlFilter;
+    private readonly IntegratedSecurityUserCredential m_user;
 
-    public AccessControlledSeekFilter(SeekFilterBase<TKey> seekFilter, Func<TKey, AccessControlSeekPosition, bool> accessControlFilter)
+    public AccessControlledSeekFilter(SeekFilterBase<TKey> seekFilter, IntegratedSecurityUserCredential user, Func<IntegratedSecurityUserCredential, TKey, AccessControlSeekPosition, bool> accessControlFilter)
     {
         m_seekFilter = seekFilter;
+        m_user = user;
         m_accessControlFilter = accessControlFilter;
     }
 
@@ -43,7 +46,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.EndOfFrame;
         set
         {
-            if (m_accessControlFilter(value, End))
+            if (m_accessControlFilter(m_user, value, End))
                 m_seekFilter.EndOfFrame = value;
             else
                 m_seekFilter.EndOfFrame.SetMin();
@@ -56,7 +59,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.EndOfRange;
         set
         {
-            if (m_accessControlFilter(value, End))
+            if (m_accessControlFilter(m_user, value, End))
                 m_seekFilter.EndOfRange = value;
             else
                 m_seekFilter.EndOfRange.SetMin();
@@ -68,7 +71,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.StartOfFrame;
         set
         {
-            if (m_accessControlFilter(value, Start))
+            if (m_accessControlFilter(m_user, value, Start))
                 m_seekFilter.StartOfFrame = value;
             else
                 m_seekFilter.StartOfFrame.SetMax();
@@ -80,7 +83,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.StartOfRange;
         set
         {
-            if (m_accessControlFilter(value, Start))
+            if (m_accessControlFilter(m_user, value, Start))
                 m_seekFilter.StartOfRange = value;
             else
                 m_seekFilter.StartOfRange.SetMax();

--- a/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
@@ -31,14 +31,14 @@ namespace SnapDB.Snap.Filters;
 internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKey : SnapTypeBase<TKey>, new()
 {
     private readonly SeekFilterBase<TKey> m_seekFilter;
-    private readonly Func<string, TKey, AccessControlSeekPosition, bool> m_accessControlFilter;
+    private readonly Func<string, TKey, AccessControlSeekPosition, bool> m_userCanSeek;
     private readonly IntegratedSecurityUserCredential m_user;
 
-    public AccessControlledSeekFilter(SeekFilterBase<TKey> seekFilter, IntegratedSecurityUserCredential user, Func<string, TKey, AccessControlSeekPosition, bool> accessControlFilter)
+    public AccessControlledSeekFilter(SeekFilterBase<TKey> seekFilter, IntegratedSecurityUserCredential user, Func<string, TKey, AccessControlSeekPosition, bool> userCanSeek)
     {
         m_seekFilter = seekFilter;
         m_user = user;
-        m_accessControlFilter = accessControlFilter;
+        m_userCanSeek = userCanSeek;
     }
 
     public new TKey EndOfFrame
@@ -46,7 +46,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.EndOfFrame;
         set
         {
-            if (m_accessControlFilter(m_user.UserId, value, End))
+            if (m_userCanSeek(m_user.UserId, value, End))
                 m_seekFilter.EndOfFrame = value;
             else
                 m_seekFilter.EndOfFrame.SetMin();
@@ -59,7 +59,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.EndOfRange;
         set
         {
-            if (m_accessControlFilter(m_user.UserId, value, End))
+            if (m_userCanSeek(m_user.UserId, value, End))
                 m_seekFilter.EndOfRange = value;
             else
                 m_seekFilter.EndOfRange.SetMin();
@@ -71,7 +71,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.StartOfFrame;
         set
         {
-            if (m_accessControlFilter(m_user.UserId, value, Start))
+            if (m_userCanSeek(m_user.UserId, value, Start))
                 m_seekFilter.StartOfFrame = value;
             else
                 m_seekFilter.StartOfFrame.SetMax();
@@ -83,7 +83,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.StartOfRange;
         set
         {
-            if (m_accessControlFilter(m_user.UserId, value, Start))
+            if (m_userCanSeek(m_user.UserId, value, Start))
                 m_seekFilter.StartOfRange = value;
             else
                 m_seekFilter.StartOfRange.SetMax();

--- a/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
@@ -31,10 +31,10 @@ namespace SnapDB.Snap.Filters;
 internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKey : SnapTypeBase<TKey>, new()
 {
     private readonly SeekFilterBase<TKey> m_seekFilter;
-    private readonly Func<IntegratedSecurityUserCredential, TKey, AccessControlSeekPosition, bool> m_accessControlFilter;
+    private readonly Func<string, TKey, AccessControlSeekPosition, bool> m_accessControlFilter;
     private readonly IntegratedSecurityUserCredential m_user;
 
-    public AccessControlledSeekFilter(SeekFilterBase<TKey> seekFilter, IntegratedSecurityUserCredential user, Func<IntegratedSecurityUserCredential, TKey, AccessControlSeekPosition, bool> accessControlFilter)
+    public AccessControlledSeekFilter(SeekFilterBase<TKey> seekFilter, IntegratedSecurityUserCredential user, Func<string, TKey, AccessControlSeekPosition, bool> accessControlFilter)
     {
         m_seekFilter = seekFilter;
         m_user = user;
@@ -46,7 +46,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.EndOfFrame;
         set
         {
-            if (m_accessControlFilter(m_user, value, End))
+            if (m_accessControlFilter(m_user.UserId, value, End))
                 m_seekFilter.EndOfFrame = value;
             else
                 m_seekFilter.EndOfFrame.SetMin();
@@ -59,7 +59,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.EndOfRange;
         set
         {
-            if (m_accessControlFilter(m_user, value, End))
+            if (m_accessControlFilter(m_user.UserId, value, End))
                 m_seekFilter.EndOfRange = value;
             else
                 m_seekFilter.EndOfRange.SetMin();
@@ -71,7 +71,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.StartOfFrame;
         set
         {
-            if (m_accessControlFilter(m_user, value, Start))
+            if (m_accessControlFilter(m_user.UserId, value, Start))
                 m_seekFilter.StartOfFrame = value;
             else
                 m_seekFilter.StartOfFrame.SetMax();
@@ -83,7 +83,7 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         get => m_seekFilter.StartOfRange;
         set
         {
-            if (m_accessControlFilter(m_user, value, Start))
+            if (m_accessControlFilter(m_user.UserId, value, Start))
                 m_seekFilter.StartOfRange = value;
             else
                 m_seekFilter.StartOfRange.SetMax();

--- a/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
@@ -21,6 +21,8 @@
 //
 //******************************************************************************************************
 
+#pragma warning disable CA2245
+
 using SnapDB.IO;
 using SnapDB.Security.Authentication;
 using static SnapDB.Snap.Filters.AccessControlSeekPosition;
@@ -28,7 +30,7 @@ using static SnapDB.Snap.Filters.AccessControlSeekPosition;
 namespace SnapDB.Snap.Filters;
 
 // Wrapper around any SeekFilterBase to apply access control to the filter
-internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKey : SnapTypeBase<TKey>, new()
+internal sealed class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKey : SnapTypeBase<TKey>, new()
 {
     private readonly SeekFilterBase<TKey> m_seekFilter;
     private readonly Func<string, TKey, AccessControlSeekPosition, bool> m_userCanSeek;
@@ -39,12 +41,18 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         m_seekFilter = seekFilter;
         m_user = user;
         m_userCanSeek = userCanSeek;
+
+        // Reapply possibly pre-existing TKey values to ensure access control is applied
+        EndOfFrame = EndOfFrame;
+        EndOfRange = EndOfRange;
+        StartOfFrame = StartOfFrame;
+        StartOfRange = StartOfRange;
     }
 
-    public new TKey EndOfFrame
+    public override TKey EndOfFrame
     {
         get => m_seekFilter.EndOfFrame;
-        set
+        protected internal set
         {
             if (m_userCanSeek(m_user.UserId, value, End))
                 m_seekFilter.EndOfFrame = value;
@@ -53,11 +61,11 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         }
     }
 
-    public new TKey EndOfRange
+    public override TKey EndOfRange
 
     {
         get => m_seekFilter.EndOfRange;
-        set
+        protected internal set
         {
             if (m_userCanSeek(m_user.UserId, value, End))
                 m_seekFilter.EndOfRange = value;
@@ -66,10 +74,10 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         }
     }
 
-    public new TKey StartOfFrame
+    public override TKey StartOfFrame
     {
         get => m_seekFilter.StartOfFrame;
-        set
+        protected internal set
         {
             if (m_userCanSeek(m_user.UserId, value, Start))
                 m_seekFilter.StartOfFrame = value;
@@ -78,10 +86,10 @@ internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey> where TKe
         }
     }
 
-    public new TKey StartOfRange
+    public override TKey StartOfRange
     {
         get => m_seekFilter.StartOfRange;
-        set
+        protected internal set
         {
             if (m_userCanSeek(m_user.UserId, value, Start))
                 m_seekFilter.StartOfRange = value;

--- a/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
+++ b/src/SnapDB/Snap/Filters/AccessControlledSeekFilter.cs
@@ -1,0 +1,93 @@
+﻿//******************************************************************************************************
+//  AccessControlledSeekFilter.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  10/30/2023 - J. Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using SnapDB.IO;
+
+namespace SnapDB.Snap.Filters;
+
+// Wrapper around any SeekFilterBase to apply access control to the filter
+internal class AccessControlledSeekFilter<TKey> : SeekFilterBase<TKey>
+{
+    private readonly SeekFilterBase<TKey> m_seekFilter;
+    private readonly Func<TKey, bool /* isStart */, TKey> m_aclFilter;
+
+    public AccessControlledSeekFilter(SeekFilterBase<TKey> seekSeekFilter, Func<TKey, bool, TKey> aclFilter)
+    {
+        m_seekFilter = seekSeekFilter;
+        m_aclFilter = aclFilter;
+    }
+
+    /// <summary>
+    /// the end of the frame to search [Inclusive]
+    /// </summary>
+    public TKey EndOfFrame
+    {
+        get => m_seekFilter.EndOfFrame; 
+        protected internal set => m_seekFilter.EndOfFrame = m_aclFilter(value, false);
+    }
+
+    /// <summary>
+    /// the end of the entire range to search [Inclusive]
+    /// </summary>
+    public TKey EndOfRange
+
+    {
+        get => m_seekFilter.EndOfRange; 
+        protected internal set => m_seekFilter.EndOfRange = m_aclFilter(value, false);
+    }
+
+    /// <summary>
+    /// the start of the frame to search [Inclusive]
+    /// </summary>
+    public TKey StartOfFrame
+    {
+        get => m_seekFilter.StartOfFrame; 
+        protected internal set => m_seekFilter.StartOfFrame = m_aclFilter(value, true);
+    }
+
+    /// <summary>
+    /// the start of the entire range to search [Inclusive]
+    /// </summary>
+    public TKey StartOfRange
+    {
+        get => m_seekFilter.StartOfRange; 
+        protected internal set => m_seekFilter.StartOfRange = m_aclFilter(value, true);
+    }
+
+    public override Guid FilterType => m_seekFilter.FilterType;
+
+    public override void Save(BinaryStreamBase stream)
+    {
+        m_seekFilter.Save(stream);
+    }
+
+    public override void Reset()
+    {
+        m_seekFilter.Reset();
+    }
+
+    public override bool NextWindow()
+    {
+        return m_seekFilter.NextWindow();
+    }
+}

--- a/src/SnapDB/Snap/Filters/SeekFilterBase.cs
+++ b/src/SnapDB/Snap/Filters/SeekFilterBase.cs
@@ -39,12 +39,12 @@ public abstract class SeekFilterBase<TKey>
     /// <summary>
     /// Gets the end of the frame to search [Inclusive].
     /// </summary>
-    public TKey EndOfFrame { get; protected internal set; } = default!;
+    public virtual TKey EndOfFrame { get; protected internal set; } = default!;
 
     /// <summary>
     /// Gets the end of the entire range to search [Inclusive].
     /// </summary>
-    public TKey EndOfRange { get; protected internal set; } = default!;
+    public virtual TKey EndOfRange { get; protected internal set; } = default!;
 
     /// <summary>
     /// Gets the filter type identifier.
@@ -54,12 +54,12 @@ public abstract class SeekFilterBase<TKey>
     /// <summary>
     /// Gets the start of the frame to search [Inclusive].
     /// </summary>
-    public TKey StartOfFrame { get; protected internal set; } = default!;
+    public virtual TKey StartOfFrame { get; protected internal set; } = default!;
 
     /// <summary>
     /// Gets the start of the entire range to search [Inclusive].
     /// </summary>
-    public TKey StartOfRange { get; protected internal set; } = default!;
+    public virtual TKey StartOfRange { get; protected internal set; } = default!;
 
     #endregion
 

--- a/src/SnapDB/Snap/Filters/SeekFilterBase.cs
+++ b/src/SnapDB/Snap/Filters/SeekFilterBase.cs
@@ -39,12 +39,12 @@ public abstract class SeekFilterBase<TKey>
     /// <summary>
     /// the end of the frame to search [Inclusive]
     /// </summary>
-    public TKey EndOfFrame { get; protected set; }
+    public TKey EndOfFrame { get; protected internal set; }
 
     /// <summary>
     /// the end of the entire range to search [Inclusive]
     /// </summary>
-    public TKey EndOfRange { get; protected set; }
+    public TKey EndOfRange { get; protected internal set; }
 
     /// <summary>
     /// The filter guid
@@ -54,12 +54,12 @@ public abstract class SeekFilterBase<TKey>
     /// <summary>
     /// the start of the frame to search [Inclusive]
     /// </summary>
-    public TKey StartOfFrame { get; protected set; }
+    public TKey StartOfFrame { get; protected internal set; }
 
     /// <summary>
     /// the start of the entire range to search [Inclusive]
     /// </summary>
-    public TKey StartOfRange { get; protected set; }
+    public TKey StartOfRange { get; protected internal set; }
 
     #endregion
 

--- a/src/SnapDB/Snap/Filters/SeekFilterBase.cs
+++ b/src/SnapDB/Snap/Filters/SeekFilterBase.cs
@@ -29,49 +29,49 @@ using SnapDB.IO;
 namespace SnapDB.Snap.Filters;
 
 /// <summary>
-/// Represents a filter that is based on a series of ranges of the key value
+/// Represents a filter that is based on a series of ranges of the key value.
 /// </summary>
-/// <typeparam name="TKey"></typeparam>
+/// <typeparam name="TKey">The key to seek.</typeparam>
 public abstract class SeekFilterBase<TKey>
 {
     #region [ Properties ]
 
     /// <summary>
-    /// the end of the frame to search [Inclusive]
+    /// Gets the end of the frame to search [Inclusive].
     /// </summary>
-    public TKey EndOfFrame { get; protected internal set; }
+    public TKey EndOfFrame { get; protected internal set; } = default!;
 
     /// <summary>
-    /// the end of the entire range to search [Inclusive]
+    /// Gets the end of the entire range to search [Inclusive].
     /// </summary>
-    public TKey EndOfRange { get; protected internal set; }
+    public TKey EndOfRange { get; protected internal set; } = default!;
 
     /// <summary>
-    /// The filter guid
+    /// Gets the filter type identifier.
     /// </summary>
     public abstract Guid FilterType { get; }
 
     /// <summary>
-    /// the start of the frame to search [Inclusive]
+    /// Gets the start of the frame to search [Inclusive].
     /// </summary>
-    public TKey StartOfFrame { get; protected internal set; }
+    public TKey StartOfFrame { get; protected internal set; } = default!;
 
     /// <summary>
-    /// the start of the entire range to search [Inclusive]
+    /// Gets the start of the entire range to search [Inclusive].
     /// </summary>
-    public TKey StartOfRange { get; protected internal set; }
+    public TKey StartOfRange { get; protected internal set; } = default!;
 
     #endregion
 
     #region [ Methods ]
 
     /// <summary>
-    /// Serializes the filter to a stream
+    /// Serializes the filter to a stream.
     /// </summary>
-    /// <param name="stream">the stream to write to</param>
+    /// <param name="stream">Target stream for writing.</param>
     public abstract void Save(BinaryStreamBase stream);
 
-    //Seekable portion of the filter
+    // Seekable portion of the filter
 
     /// <summary>
     /// Resets the iterative nature of the filter.
@@ -85,7 +85,7 @@ public abstract class SeekFilterBase<TKey>
     /// <summary>
     /// Gets the next search window.
     /// </summary>
-    /// <returns>true if window exists, false if finished.</returns>
+    /// <returns><c>true</c>if window exists; otherwise, <c>false</c> if finished.</returns>
     public abstract bool NextWindow();
 
     #endregion

--- a/src/SnapDB/Snap/Filters/TimestampSeekFilter.cs
+++ b/src/SnapDB/Snap/Filters/TimestampSeekFilter.cs
@@ -149,12 +149,11 @@ public partial class TimestampSeekFilter
     /// <returns>A seek filter base that will be created from the specified stream.</returns>
     /// <exception cref="VersionNotFoundException">Thrown if the version cannot be reached.</exception>
     [MethodImpl(MethodImplOptions.NoOptimization)]
-    private static SeekFilterBase<TKey> CreateFromStream<TKey>(BinaryStreamBase stream) where TKey : TimestampPointIDBase<TKey>, new()
+    private static SeekFilterBase<TKey>? CreateFromStream<TKey>(BinaryStreamBase stream) where TKey : TimestampPointIDBase<TKey>, new()
     {
         byte version = stream.ReadUInt8();
 
-        return version 
-            switch
+        return version switch
         {
             0 => null,
             1 => new FixedRange<TKey>(stream),

--- a/src/SnapDB/Snap/Services/ArchiveDetails.cs
+++ b/src/SnapDB/Snap/Services/ArchiveDetails.cs
@@ -23,8 +23,6 @@
 //       Converted code to .NET core.
 //
 //******************************************************************************************************
-using System.Linq;
-
 
 namespace SnapDB.Snap.Services;
 

--- a/src/SnapDB/Snap/Services/ArchiveDetails.cs
+++ b/src/SnapDB/Snap/Services/ArchiveDetails.cs
@@ -23,6 +23,8 @@
 //       Converted code to .NET core.
 //
 //******************************************************************************************************
+using System.Linq;
+
 
 namespace SnapDB.Snap.Services;
 
@@ -41,6 +43,15 @@ public class ArchiveDetails
 
     #region [ Properties ]
 
+
+    /// <summary>
+    /// Gets the start time of the archive, if applicable to Key type.
+    /// </summary>
+    /// <remarks>
+    /// If Key type does not expose a TimestampAsDate property, value will be <see cref="DateTime.MinValue"/>.
+    /// </remarks>
+    public DateTime StartTime { get; private set; }
+
     /// <summary>
     /// Gets the end time of the archive, if applicable to Key type.
     /// </summary>
@@ -50,7 +61,7 @@ public class ArchiveDetails
     public DateTime EndTime { get; private set; }
 
     /// <summary>
-    /// The name of the file
+    /// The name of the file.
     /// </summary>
     public string FileName { get; private set; }
 
@@ -60,14 +71,14 @@ public class ArchiveDetails
     public long FileSize { get; private set; }
 
     /// <summary>
-    /// Gets the first key as a string.
-    /// </summary>
-    public string FirstKey { get; private set; }
-
-    /// <summary>
-    /// The ID for the file
+    /// The ID for the file.
     /// </summary>
     public Guid Id { get; private set; }
+
+    /// <summary>
+    /// Gets the flags for the archive file.
+    /// </summary>
+    public Guid[] Flags { get; private set; }
 
     /// <summary>
     /// Gets if the file contains anything.
@@ -75,17 +86,14 @@ public class ArchiveDetails
     public bool IsEmpty { get; private set; }
 
     /// <summary>
+    /// Gets the first key as a string.
+    /// </summary>
+    public string FirstKey { get; private set; }
+
+    /// <summary>
     /// Gets the last key as a string.
     /// </summary>
     public string LastKey { get; private set; }
-
-    /// <summary>
-    /// Gets the start time of the archive, if applicable to Key type.
-    /// </summary>
-    /// <remarks>
-    /// If Key type does not expose a TimestampAsDate property, value will be <see cref="DateTime.MinValue"/>.
-    /// </remarks>
-    public DateTime StartTime { get; private set; }
 
     #endregion
 
@@ -99,7 +107,9 @@ public class ArchiveDetails
     /// <param name="table">The ArchiveTableSummary to create details from.</param>
     /// <returns>An ArchiveDetails object containing information about the archive table.</returns>
 
-    public static ArchiveDetails Create<TKey, TValue>(ArchiveTableSummary<TKey, TValue> table) where TKey : SnapTypeBase<TKey>, new() where TValue : SnapTypeBase<TValue>, new()
+    public static ArchiveDetails Create<TKey, TValue>(ArchiveTableSummary<TKey, TValue> table) 
+        where TKey : SnapTypeBase<TKey>, new() 
+        where TValue : SnapTypeBase<TValue>, new()
     {
         ArchiveDetails details = new()
         {
@@ -108,7 +118,8 @@ public class ArchiveDetails
             IsEmpty = table.IsEmpty,
             FileSize = table.SortedTreeTable.BaseFile.ArchiveSize,
             FirstKey = table.FirstKey.ToString(),
-            LastKey = table.LastKey.ToString()
+            LastKey = table.LastKey.ToString(),
+            Flags = table.SortedTreeTable.BaseFile.Snapshot.Header.Flags.ToArray()
         };
 
     #if SQLCLR
@@ -132,6 +143,5 @@ public class ArchiveDetails
     #endif
         return details;
     }
-
     #endregion
 }

--- a/src/SnapDB/Snap/Services/ArchiveDirectoryMethod.cs
+++ b/src/SnapDB/Snap/Services/ArchiveDirectoryMethod.cs
@@ -32,22 +32,22 @@ namespace SnapDB.Snap.Services;
 public enum ArchiveDirectoryMethod
 {
     /// <summary>
-    /// Writes all files in the top directory
+    /// Writes all files in the top directory.
     /// </summary>
     TopDirectoryOnly,
 
     /// <summary>
-    /// Writes all files based on the starting year
+    /// Writes all files based on the starting year.
     /// </summary>
     Year,
 
     /// <summary>
-    /// Writes all files based on 'YearMonth'
+    /// Writes all files based on 'YearMonth'.
     /// </summary>
     YearMonth,
 
     /// <summary>
-    /// Writes all files based on 'Year\Month'
+    /// Writes all files based on 'Year\Month'.
     /// </summary>
     YearThenMonth
 }

--- a/src/SnapDB/Snap/Services/Net/SnapNetworkServer.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapNetworkServer.cs
@@ -52,6 +52,9 @@ internal class SnapNetworkServer : SnapStreamingServer
         m_rawStream = new NetworkStream(m_client.Client);
         m_client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, true);
 
+        // TODO: Get client from negotiated authentication on socket
+        // User = <get user info>;
+
         Initialize(authentication, m_rawStream, server, requireSsl);
     }
 

--- a/src/SnapDB/Snap/Services/Net/SnapNetworkServer.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapNetworkServer.cs
@@ -28,6 +28,7 @@ using System.Net.Sockets;
 using System.Text;
 using Gemstone.Diagnostics;
 using SnapDB.Security;
+using SnapDB.Security.Authentication;
 
 namespace SnapDB.Snap.Services.Net;
 
@@ -46,14 +47,14 @@ internal class SnapNetworkServer : SnapStreamingServer
 
     #region [ Constructors ]
 
-    public SnapNetworkServer(SecureStreamServer<SocketUserPermissions> authentication, TcpClient client, SnapServer server, bool requireSsl = false)
+    public SnapNetworkServer(SecureStreamServer<SocketUserPermissions> authentication, TcpClient client, SnapServer server, string? defaultUser, bool requireSsl = false)
     {
         m_client = client;
         m_rawStream = new NetworkStream(m_client.Client);
         m_client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, true);
 
         // TODO: Must fix! Get client from negotiated authentication on socket:
-        User = null;
+        User = string.IsNullOrWhiteSpace(defaultUser) ? null : new IntegratedSecurityUserCredential(defaultUser, Guid.NewGuid());
 
         Initialize(authentication, m_rawStream, server, requireSsl);
     }

--- a/src/SnapDB/Snap/Services/Net/SnapNetworkServer.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapNetworkServer.cs
@@ -52,8 +52,8 @@ internal class SnapNetworkServer : SnapStreamingServer
         m_rawStream = new NetworkStream(m_client.Client);
         m_client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, true);
 
-        // TODO: Get client from negotiated authentication on socket
-        // User = <get user info>;
+        // TODO: Must fix! Get client from negotiated authentication on socket:
+        User = null;
 
         Initialize(authentication, m_rawStream, server, requireSsl);
     }
@@ -91,7 +91,7 @@ internal class SnapNetworkServer : SnapStreamingServer
     {
         try
         {
-            status.AppendLine(m_client.Client.RemoteEndPoint.ToString());
+            status.AppendLine(m_client.Client.RemoteEndPoint?.ToString());
         }
         catch (Exception)
         {

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
@@ -180,8 +180,9 @@ public class SnapSocketListener : DisposableLoggingClassBase
             {
                 networkServerProcessing = new SnapNetworkServer(m_authenticator, client, m_server)
                 {
-                    AccessControlSeekFilter = m_settings.AccessControlSeekFilter,
-                    AccessControlMatchFilter = m_settings.AccessControlMatchFilter
+                    UserCanSeek = m_settings.UserCanSeek,
+                    UserCanMatch = m_settings.UserCanMatch,
+                    UserCanWrite = m_settings.UserCanWrite
                 };
             }
 

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
@@ -178,7 +178,7 @@ public class SnapSocketListener : DisposableLoggingClassBase
 
             using (Logger.AppendStackMessages(Log.InitialStackMessages))
             {
-                networkServerProcessing = new SnapNetworkServer(m_authenticator, client, m_server)
+                networkServerProcessing = new SnapNetworkServer(m_authenticator, client, m_server, m_settings.DefaultUser)
                 {
                     UserCanSeek = m_settings.UserCanSeek,
                     UserCanMatch = m_settings.UserCanMatch,

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
@@ -177,11 +177,13 @@ public class SnapSocketListener : DisposableLoggingClassBase
             SnapNetworkServer networkServerProcessing;
 
             using (Logger.AppendStackMessages(Log.InitialStackMessages))
-                networkServerProcessing = new SnapNetworkServer(m_authenticator, client, m_server);
-
-            // Apply any defined access controlled filter functions
-            networkServerProcessing.AccessControlledSeekFilter = m_settings.AccessControlledSeekFilter;
-            networkServerProcessing.AccessControlledMatchFilter = m_settings.AccessControlledMatchFilter;
+            {
+                networkServerProcessing = new SnapNetworkServer(m_authenticator, client, m_server)
+                {
+                    AccessControlSeekFilter = m_settings.AccessControlSeekFilter,
+                    AccessControlMatchFilter = m_settings.AccessControlMatchFilter
+                };
+            }
 
             lock (m_clients)
             {

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListener.cs
@@ -67,6 +67,7 @@ public class SnapSocketListener : DisposableLoggingClassBase
         m_settings = settings.CloneReadonly();
         m_settings.Validate();
 
+        // Authenticator exposes "Users" property to allow looks ups of user permissions
         m_authenticator = new SecureStreamServer<SocketUserPermissions>();
 
         if (settings.DefaultUserCanRead || settings.DefaultUserCanWrite || settings.DefaultUserIsAdmin)
@@ -108,30 +109,32 @@ public class SnapSocketListener : DisposableLoggingClassBase
     /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
     protected override void Dispose(bool disposing)
     {
-        if (!m_disposed)
-            try
+        if (m_disposed)
+            return;
+
+        try
+        {
+            if (!disposing)
+                return;
+
+            m_isRunning = false;
+
+            m_listener?.Stop();
+
+            m_server = null;
+
+            lock (m_clients)
             {
-                if (!disposing)
-                    return;
-
-                m_isRunning = false;
-
-                m_listener?.Stop();
-
-                m_server = null;
-
-                lock (m_clients)
-                {
-                    foreach (SnapNetworkServer client in m_clients)
-                        client.Dispose();
-                    m_clients.Clear();
-                }
+                foreach (SnapNetworkServer client in m_clients)
+                    client.Dispose();
+                m_clients.Clear();
             }
-            finally
-            {
-                m_disposed = true; // Prevent duplicate dispose.
-                base.Dispose(disposing); // Call base class Dispose().
-            }
+        }
+        finally
+        {
+            m_disposed = true; // Prevent duplicate dispose.
+            base.Dispose(disposing); // Call base class Dispose().
+        }
     }
 
     /// <summary>
@@ -175,6 +178,10 @@ public class SnapSocketListener : DisposableLoggingClassBase
 
             using (Logger.AppendStackMessages(Log.InitialStackMessages))
                 networkServerProcessing = new SnapNetworkServer(m_authenticator, client, m_server);
+
+            // Apply any defined access controlled filter functions
+            networkServerProcessing.AccessControlledSeekFilter = m_settings.AccessControlledSeekFilter;
+            networkServerProcessing.AccessControlledMatchFilter = m_settings.AccessControlledMatchFilter;
 
             lock (m_clients)
             {

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
@@ -152,19 +152,45 @@ public class SnapSocketListenerSettings : SettingsBase<SnapSocketListenerSetting
     }
 
     /// <summary>
-    /// A list of all Windows users that are allowed to connect to the historian.
+    /// A list of all users that are allowed to connect to the historian.
     /// </summary>
     public ImmutableList<string> Users { get; } = new();
 
     /// <summary>
-    /// Gets or sets any defined access control seek filter function.
+    /// Gets or sets any defined user read access control function for seek filters.
     /// </summary>
-    public Func<IntegratedSecurityUserCredential, object /*TKey*/, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
+    /// <remarks>
+    /// Function parameters are: <br/>
+    /// <c>string UserId</c> - The user security ID (SID) of the user attempting to seek.<br/>
+    /// <c>TKey instance</c> - The key of the record being sought.<br/>
+    /// <c>AccessControlSeekPosition</c> - The position of the seek. i.e., <c>Start</c> or <c>End</c>.<br/>
+    /// <c>bool</c> - Return <c>true</c> if user is allowed to seek; otherwise, <c>false</c>.
+    /// </remarks>
+    public Func<string /*UserId*/, object /*TKey*/, AccessControlSeekPosition, bool>? UserCanSeek { get; set; }
 
     /// <summary>
-    /// Gets or sets any defined access control match filter function.
+    /// Gets or sets any defined user read access control function for match filters.
     /// </summary>
-    public Func<IntegratedSecurityUserCredential, object /*TKey*/, object /*TValue*/, bool>? AccessControlMatchFilter { get; set; }
+    /// <remarks>
+    /// Function parameters are: <br/>
+    /// <c>string UserId</c> - The user security ID (SID) of the user attempting to match.<br/>
+    /// <c>TKey instance</c> - The key of the record being matched.<br/>
+    /// <c>TValue instance</c> - The value of the record being matched.<br/>
+    /// <c>bool</c> - Return <c>true</c> if user is allowed to match; otherwise, <c>false</c>.
+    /// </remarks>
+    public Func<string /*UserId*/, object /*TKey*/, object /*TValue*/, bool>? UserCanMatch { get; set; }
+
+    /// <summary>
+    /// Gets or sets any defined user write access control function.
+    /// </summary>
+    /// <remarks>
+    /// Function parameters are: <br/>
+    /// <c>string UserId</c> - The user security ID (SID) of the user attempting to write.<br/>
+    /// <c>TKey instance</c> - The key of the record being written.<br/>
+    /// <c>TValue instance</c> - The value of the record being written.<br/>
+    /// <c>bool</c> - Return <c>true</c> if user is allowed to write; otherwise, <c>false</c>.
+    /// </remarks>
+    public Func<string /*UserId*/, object /*TKey*/, object /*TValue*/, bool>? UserCanWrite { get; set; }
 
     #endregion
 

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
@@ -32,6 +32,7 @@ using System.Net;
 using Gemstone.Communication;
 using Gemstone.IO.StreamExtensions;
 using SnapDB.Immutables;
+using SnapDB.Snap.Filters;
 
 // ReSharper disable RedundantDefaultMemberInitializer
 namespace SnapDB.Snap.Services.Net;
@@ -155,14 +156,14 @@ public class SnapSocketListenerSettings : SettingsBase<SnapSocketListenerSetting
     public ImmutableList<string> Users { get; } = new();
 
     /// <summary>
-    /// Gets or sets any defined access controlled seek filter function.
+    /// Gets or sets any defined access control seek filter function.
     /// </summary>
-    public Func<object /*TKey*/, bool /*isStart*/, object /*TKey result*/>? AccessControlledSeekFilter { get; set; }
+    public Func<object /*TKey*/, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
 
     /// <summary>
-    /// Gets or sets any defined access controlled match filter function.
+    /// Gets or sets any defined access control match filter function.
     /// </summary>
-    public Func<object /*TKey*/, object /*TValue*/, bool /*contains*/>? AccessControlledMatchFilter { get; set; }
+    public Func<object /*TKey*/, object /*TValue*/, bool>? AccessControlMatchFilter { get; set; }
 
     #endregion
 

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
@@ -154,6 +154,16 @@ public class SnapSocketListenerSettings : SettingsBase<SnapSocketListenerSetting
     /// </summary>
     public ImmutableList<string> Users { get; } = new();
 
+    /// <summary>
+    /// Gets or sets any defined access controlled seek filter function.
+    /// </summary>
+    public Func<object /*TKey*/, bool /*isStart*/, object /*TKey result*/>? AccessControlledSeekFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets any defined access controlled match filter function.
+    /// </summary>
+    public Func<object /*TKey*/, object /*TValue*/, bool /*contains*/>? AccessControlledMatchFilter { get; set; }
+
     #endregion
 
     #region [ Methods ]

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
@@ -32,6 +32,7 @@ using System.Net;
 using Gemstone.Communication;
 using Gemstone.IO.StreamExtensions;
 using SnapDB.Immutables;
+using SnapDB.Security.Authentication;
 using SnapDB.Snap.Filters;
 
 // ReSharper disable RedundantDefaultMemberInitializer
@@ -158,12 +159,12 @@ public class SnapSocketListenerSettings : SettingsBase<SnapSocketListenerSetting
     /// <summary>
     /// Gets or sets any defined access control seek filter function.
     /// </summary>
-    public Func<object /*TKey*/, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
+    public Func<IntegratedSecurityUserCredential, object /*TKey*/, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
 
     /// <summary>
     /// Gets or sets any defined access control match filter function.
     /// </summary>
-    public Func<object /*TKey*/, object /*TValue*/, bool>? AccessControlMatchFilter { get; set; }
+    public Func<IntegratedSecurityUserCredential, object /*TKey*/, object /*TValue*/, bool>? AccessControlMatchFilter { get; set; }
 
     #endregion
 

--- a/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapSocketListenerSettings.cs
@@ -32,7 +32,6 @@ using System.Net;
 using Gemstone.Communication;
 using Gemstone.IO.StreamExtensions;
 using SnapDB.Immutables;
-using SnapDB.Security.Authentication;
 using SnapDB.Snap.Filters;
 
 // ReSharper disable RedundantDefaultMemberInitializer
@@ -79,7 +78,7 @@ public class SnapSocketListenerSettings : SettingsBase<SnapSocketListenerSetting
     private bool m_forceSsl = false;
 
     // The local IP address to host on. Leave empty to bind to all local interfaces.
-    private string m_localIPAddress = DefaultIPAddress;
+    private string? m_localIPAddress = DefaultIPAddress;
 
     // The local TCP port to host on.
     private int m_localTcpPort = DefaultNetworkPort;
@@ -128,7 +127,7 @@ public class SnapSocketListenerSettings : SettingsBase<SnapSocketListenerSetting
     /// <summary>
     /// The local IP address to host on. Leave empty to bind to all local interfaces.
     /// </summary>
-    public string LocalIPAddress
+    public string? LocalIPAddress
     {
         get => m_localIPAddress;
         set
@@ -150,6 +149,11 @@ public class SnapSocketListenerSettings : SettingsBase<SnapSocketListenerSetting
             m_localTcpPort = value;
         }
     }
+
+    /// <summary>
+    /// Gets or sets any default user name that should be used if no other user name can be determined.
+    /// </summary>
+    public string? DefaultUser { get; set; }
 
     /// <summary>
     /// A list of all users that are allowed to connect to the historian.

--- a/src/SnapDB/Snap/Services/Net/SnapStreamingServer.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapStreamingServer.cs
@@ -87,17 +87,43 @@ public class SnapStreamingServer : DisposableLoggingClassBase
     /// <summary>
     /// Gets or sets user associated with this streaming server.
     /// </summary>
-    protected IntegratedSecurityUserCredential User { get; set; }
+    protected IntegratedSecurityUserCredential? User { get; set; }
 
     /// <summary>
-    /// Gets or sets any defined access control seek filter function.
+    /// Gets or sets any defined user read access control function for seek filters.
     /// </summary>
-    public Func<IntegratedSecurityUserCredential, object, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
+    /// <remarks>
+    /// Function parameters are: <br/>
+    /// <c>string UserId</c> - The user security ID (SID) of the user attempting to seek.<br/>
+    /// <c>TKey instance</c> - The key of the record being sought.<br/>
+    /// <c>AccessControlSeekPosition</c> - The position of the seek. i.e., <c>Start</c> or <c>End</c>.<br/>
+    /// <c>bool</c> - Return <c>true</c> if user is allowed to seek; otherwise, <c>false</c>.
+    /// </remarks>
+    public Func<string /*UserId*/, object /*TKey*/, AccessControlSeekPosition, bool>? UserCanSeek { get; set; }
 
     /// <summary>
-    /// Gets or sets any defined access control match filter function.
+    /// Gets or sets any defined user read access control function for match filters.
     /// </summary>
-    public Func<IntegratedSecurityUserCredential, object, object, bool>? AccessControlMatchFilter { get; set; }
+    /// <remarks>
+    /// Function parameters are: <br/>
+    /// <c>string UserId</c> - The user security ID (SID) of the user attempting to match.<br/>
+    /// <c>TKey instance</c> - The key of the record being matched.<br/>
+    /// <c>TValue instance</c> - The value of the record being matched.<br/>
+    /// <c>bool</c> - Return <c>true</c> if user is allowed to match; otherwise, <c>false</c>.
+    /// </remarks>
+    public Func<string /*UserId*/, object /*TKey*/, object /*TValue*/, bool>? UserCanMatch { get; set; }
+
+    /// <summary>
+    /// Gets or sets any defined user write access control function.
+    /// </summary>
+    /// <remarks>
+    /// Function parameters are: <br/>
+    /// <c>string UserId</c> - The user security ID (SID) of the user attempting to write.<br/>
+    /// <c>TKey instance</c> - The key of the record being written.<br/>
+    /// <c>TValue instance</c> - The value of the record being written.<br/>
+    /// <c>bool</c> - Return <c>true</c> if user is allowed to write; otherwise, <c>false</c>.
+    /// </remarks>
+    public Func<string /*UserId*/, object /*TKey*/, object /*TValue*/, bool>? UserCanWrite { get; set; }
 
     #endregion
 
@@ -170,7 +196,7 @@ public class SnapStreamingServer : DisposableLoggingClassBase
                 Logger.SwallowException(ex2);
             }
 
-            Log.Publish(MessageLevel.Warning, "Socket Exception", "Exception occured, Client will be disconnected.", null, ex);
+            Log.Publish(MessageLevel.Warning, "Socket Exception", "Exception occurred, Client will be disconnected.", null, ex);
         }
         finally
         {
@@ -251,7 +277,7 @@ public class SnapStreamingServer : DisposableLoggingClassBase
                     Type type = typeof(SnapStreamingServer);
                     MethodInfo method = type.GetMethod(nameof(ConnectToDatabase), BindingFlags.NonPublic | BindingFlags.Instance);
                     MethodInfo reflectionMethod = method?.MakeGenericMethod(database.Info.KeyType, database.Info.ValueType);
-                    bool success = (bool?)reflectionMethod?.Invoke(this, new object[] { database, User, AccessControlSeekFilter!, AccessControlMatchFilter! }) ?? false;
+                    bool success = (bool?)reflectionMethod?.Invoke(this, new object[] { database, User, UserCanSeek!, UserCanMatch!, UserCanWrite! }) ?? false;
 
                     if (!success)
                         return;
@@ -277,8 +303,9 @@ public class SnapStreamingServer : DisposableLoggingClassBase
     (
         SnapServerDatabase<TKey, TValue>.ClientDatabase database, 
         IntegratedSecurityUserCredential user, 
-        Func<IntegratedSecurityUserCredential, object, AccessControlSeekPosition, bool>? accessControlSeekFilter, 
-        Func<IntegratedSecurityUserCredential, object, object, bool>? accessControlMatchFilter
+        Func<string, object, AccessControlSeekPosition, bool>? userCanSeek, 
+        Func<string, object, object, bool>? userCanMatch,
+        Func<string, object, object, bool>? userCanWrite
     ) 
     where TKey : SnapTypeBase<TKey>, new() where TValue : SnapTypeBase<TValue>, new()
     {
@@ -287,8 +314,9 @@ public class SnapStreamingServer : DisposableLoggingClassBase
 
         StreamingServerDatabase<TKey, TValue> engine = new(m_stream, database, user)
         { 
-            AccessControlSeekFilter = accessControlSeekFilter,
-            AccessControlMatchFilter = accessControlMatchFilter
+            UserCanSeek = userCanSeek,
+            UserCanMatch = userCanMatch,
+            UserCanWrite = userCanWrite
         };
 
         return engine.RunDatabaseLevel();

--- a/src/SnapDB/Snap/Services/Net/SnapStreamingServer.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapStreamingServer.cs
@@ -92,12 +92,12 @@ public class SnapStreamingServer : DisposableLoggingClassBase
     /// <summary>
     /// Gets or sets any defined access control seek filter function.
     /// </summary>
-    public Func<object, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
+    public Func<IntegratedSecurityUserCredential, object, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
 
     /// <summary>
     /// Gets or sets any defined access control match filter function.
     /// </summary>
-    public Func<object, object, bool>? AccessControlMatchFilter { get; set; }
+    public Func<IntegratedSecurityUserCredential, object, object, bool>? AccessControlMatchFilter { get; set; }
 
     #endregion
 
@@ -277,8 +277,8 @@ public class SnapStreamingServer : DisposableLoggingClassBase
     (
         SnapServerDatabase<TKey, TValue>.ClientDatabase database, 
         IntegratedSecurityUserCredential user, 
-        Func<object, AccessControlSeekPosition, bool>? accessControlSeekFilter, 
-        Func<object, object, bool>? accessControlMatchFilter
+        Func<IntegratedSecurityUserCredential, object, AccessControlSeekPosition, bool>? accessControlSeekFilter, 
+        Func<IntegratedSecurityUserCredential, object, object, bool>? accessControlMatchFilter
     ) 
     where TKey : SnapTypeBase<TKey>, new() where TValue : SnapTypeBase<TValue>, new()
     {

--- a/src/SnapDB/Snap/Services/Net/StreamingServerDatabase.cs
+++ b/src/SnapDB/Snap/Services/Net/StreamingServerDatabase.cs
@@ -64,14 +64,14 @@ internal class StreamingServerDatabase<TKey, TValue> where TKey : SnapTypeBase<T
     #region [ Properties ]
 
     /// <summary>
-    /// Gets or sets any defined access controlled seek filter function.
+    /// Gets or sets any defined access control seek filter function.
     /// </summary>
-    public Func<TKey, bool, TKey>? AccessControlledSeekFilter { get; set; }
+    public Func<TKey, AccessControlSeekPosition, bool>? AccessControlSeekFilter { get; set; }
 
     /// <summary>
-    /// Gets or sets any defined access controlled match filter function.
+    /// Gets or sets any defined access control match filter function.
     /// </summary>
-    public Func<TKey, TValue, bool>? AccessControlledMatchFilter { get; set; }
+    public Func<TKey, TValue, bool>? AccessControlMatchFilter { get; set; }
 
     #endregion
 
@@ -147,8 +147,8 @@ internal class StreamingServerDatabase<TKey, TValue> where TKey : SnapTypeBase<T
             {
                 key1Parser = Library.Filters.GetSeekFilter<TKey>(m_stream.ReadGuid(), m_stream);
 
-                if (AccessControlledSeekFilter is not null)
-                    key1Parser = new AccessControlledSeekFilter<TKey>(key1Parser, AccessControlledSeekFilter);
+                if (AccessControlSeekFilter is not null)
+                    key1Parser = new AccessControlledSeekFilter<TKey>(key1Parser, AccessControlSeekFilter);
             }
             catch
             {
@@ -165,8 +165,8 @@ internal class StreamingServerDatabase<TKey, TValue> where TKey : SnapTypeBase<T
             {
                 key2Parser = Library.Filters.GetMatchFilter<TKey, TValue>(m_stream.ReadGuid(), m_stream);
 
-                if (AccessControlledMatchFilter is not null)
-                    key2Parser = new AccessControlledMatchFilter<TKey, TValue>(key2Parser, AccessControlledMatchFilter);
+                if (AccessControlMatchFilter is not null)
+                    key2Parser = new AccessControlledMatchFilter<TKey, TValue>(key2Parser, AccessControlMatchFilter);
             }
             catch
             {

--- a/src/SnapDB/Snap/Services/Net/StreamingServerDatabase.cs
+++ b/src/SnapDB/Snap/Services/Net/StreamingServerDatabase.cs
@@ -38,7 +38,6 @@ namespace SnapDB.Snap.Services.Net;
 /// <typeparam name="TKey"></typeparam>
 /// <typeparam name="TValue"></typeparam>
 internal class StreamingServerDatabase<TKey, TValue> where TKey : SnapTypeBase<TKey>, new() where TValue : SnapTypeBase<TValue>, new()
-
 {
     #region [ Members ]
 
@@ -186,6 +185,10 @@ internal class StreamingServerDatabase<TKey, TValue> where TKey : SnapTypeBase<T
                 return false;
             }
         }
+        else if (UserCanSeek is not null)
+        {
+            key1Parser = new AccessControlledSeekFilter<TKey>(new SeekFilterUniverse<TKey>(), m_user, UserCanSeek);
+        }
 
         if (m_stream.ReadBoolean())
         {
@@ -203,6 +206,10 @@ internal class StreamingServerDatabase<TKey, TValue> where TKey : SnapTypeBase<T
 
                 return false;
             }
+        }
+        else if (UserCanMatch is not null)
+        {
+            key2Parser = new AccessControlledMatchFilter<TKey, TValue>(new MatchFilterUniverse<TKey, TValue>(), m_user, UserCanMatch);
         }
 
         if (m_stream.ReadBoolean())

--- a/src/SnapDB/Snap/Services/SnapServer.cs
+++ b/src/SnapDB/Snap/Services/SnapServer.cs
@@ -225,7 +225,6 @@ public partial class SnapServer : DisposableLoggingClassBase
         }
     }
 
-
     /// <summary>
     /// Unloads the database name.
     /// </summary>

--- a/src/SnapDB/Snap/Services/SnapServerDatabase.cs
+++ b/src/SnapDB/Snap/Services/SnapServerDatabase.cs
@@ -224,7 +224,7 @@ public partial class SnapServerDatabase<TKey, TValue> : SnapServerDatabaseBase w
             Write(key, value);
     }
 
-    private SequentialReaderStream<TKey, TValue> Read(SortedTreeEngineReaderOptions? readerOptions, SeekFilterBase<TKey> keySeekFilter, MatchFilterBase<TKey, TValue>? keyMatchFilter, WorkerThreadSynchronization workerThreadSynchronization)
+    private SequentialReaderStream<TKey, TValue> Read(SortedTreeEngineReaderOptions? readerOptions, SeekFilterBase<TKey>? keySeekFilter, MatchFilterBase<TKey, TValue>? keyMatchFilter, WorkerThreadSynchronization workerThreadSynchronization)
     {
         if (m_disposed)
             throw new ObjectDisposedException(GetType().FullName);

--- a/src/SnapDB/Snap/Services/SnapServerDatabase_ClientDatabase.cs
+++ b/src/SnapDB/Snap/Services/SnapServerDatabase_ClientDatabase.cs
@@ -167,12 +167,12 @@ public partial class SnapServerDatabase<TKey, TValue>
         /// <param name="keySeekFilter">a seek based filter to follow. Can be null.</param>
         /// <param name="keyMatchFilter">a match based filer to follow. Can be null.</param>
         /// <returns>A stream that will read the specified data.</returns>
-        public override TreeStream<TKey, TValue> Read(SortedTreeEngineReaderOptions? readerOptions, SeekFilterBase<TKey> keySeekFilter, MatchFilterBase<TKey, TValue>? keyMatchFilter)
+        public override TreeStream<TKey, TValue> Read(SortedTreeEngineReaderOptions? readerOptions, SeekFilterBase<TKey>? keySeekFilter, MatchFilterBase<TKey, TValue>? keyMatchFilter)
         {
             return Read(readerOptions, keySeekFilter, keyMatchFilter, null);
         }
 
-        public TreeStream<TKey, TValue> Read(SortedTreeEngineReaderOptions? readerOptions, SeekFilterBase<TKey> keySeekFilter, MatchFilterBase<TKey, TValue>? keyMatchFilter, WorkerThreadSynchronization workerThreadSynchronization)
+        public TreeStream<TKey, TValue> Read(SortedTreeEngineReaderOptions? readerOptions, SeekFilterBase<TKey>? keySeekFilter, MatchFilterBase<TKey, TValue>? keyMatchFilter, WorkerThreadSynchronization? workerThreadSynchronization)
         {
             if (m_disposed)
                 throw new ObjectDisposedException(GetType().FullName);

--- a/src/SnapDB/Snap/Services/Writer/CombineFilesSettings.cs
+++ b/src/SnapDB/Snap/Services/Writer/CombineFilesSettings.cs
@@ -83,10 +83,10 @@ public class CombineFilesSettings : SettingsBase<CombineFilesSettings>
     }
 
     /// <summary>
-    /// The size at which to create a rolled over file
+    /// The size at which to create a rolled over file.
     /// </summary>
     /// <remarks>
-    /// Must be between 1MB and 100GB
+    /// Must be between 1MB and 100GB.
     /// </remarks>
     public long CombineOnFileSize
     {

--- a/src/SnapDB/Snap/SnapTypeBase.cs
+++ b/src/SnapDB/Snap/SnapTypeBase.cs
@@ -63,12 +63,12 @@ public abstract class SnapTypeBase
     #region [ Methods ]
 
     /// <summary>
-    /// Sets the provided key to it's minimum value.
+    /// Sets the provided key to its minimum value.
     /// </summary>
     public abstract void SetMin();
 
     /// <summary>
-    /// Sets the privided key to it's maximum value.
+    /// Sets the provided key to its maximum value.
     /// </summary>
     public abstract void SetMax();
 
@@ -96,9 +96,12 @@ public abstract class SnapTypeBase
     public virtual unsafe void Read(Stream stream)
     {
         byte[] data = new byte[Size];
+        
+        // ReSharper disable once MustUseReturnValue
         stream.Read(data, 0, data.Length);
-        fixed (byte* lp = data)
-            Read(lp);
+        
+        fixed (byte* ptr = data)
+            Read(ptr);
     }
 
     /// <summary>
@@ -108,8 +111,9 @@ public abstract class SnapTypeBase
     public virtual unsafe void Write(Stream stream)
     {
         byte[] data = new byte[Size];
-        fixed (byte* lp = data)
-            Write(lp);
+
+        fixed (byte* ptr = data)
+            Write(ptr);
 
         stream.Write(data, 0, data.Length);
     }

--- a/src/SnapDB/Snap/SnapTypeBase_1.cs
+++ b/src/SnapDB/Snap/SnapTypeBase_1.cs
@@ -92,7 +92,7 @@ public abstract class SnapTypeBase<T> : SnapTypeBase, IComparable<T>, IEquatable
     /// <returns>
     /// <c>true</c> if the current instance is equal to the <paramref name="right"/> instance; otherwise, <c>false</c>.
     /// </returns>
-    public virtual bool IsEqualTo(T right)
+    public virtual bool IsEqualTo(T? right)
     {
         return CompareTo(right) == 0;
     }
@@ -104,7 +104,7 @@ public abstract class SnapTypeBase<T> : SnapTypeBase, IComparable<T>, IEquatable
     /// <returns>
     /// <c>true</c> if the current instance is not equal to the <paramref name="right"/> instance; otherwise, <c>false</c>.
     /// </returns>
-    public virtual bool IsNotEqualTo(T right)
+    public virtual bool IsNotEqualTo(T? right)
     {
         return CompareTo(right) != 0;
     }
@@ -177,9 +177,9 @@ public abstract class SnapTypeBase<T> : SnapTypeBase, IComparable<T>, IEquatable
     /// <returns>A new instance that is a copy of the current instance.</returns>
     public virtual T Clone()
     {
-        T rv = new();
-        CopyTo(rv);
-        return rv;
+        T clone = new();
+        CopyTo(clone);
+        return clone;
     }
 
     /// <summary>
@@ -189,7 +189,7 @@ public abstract class SnapTypeBase<T> : SnapTypeBase, IComparable<T>, IEquatable
     /// <returns>
     /// A value that indicates the relative order of the objects being compared.
     /// </returns>
-    public abstract int CompareTo(T other);
+    public abstract int CompareTo(T? other);
 
     /// <summary>
     /// Compares two objects and returns a value indicating whether one is less than, equal to, or greater than the other.
@@ -199,9 +199,14 @@ public abstract class SnapTypeBase<T> : SnapTypeBase, IComparable<T>, IEquatable
     /// </returns>
     /// <param name="x">The first object to compare.</param>
     /// <param name="y">The second object to compare.</param>
-    public virtual int Compare(T x, T y)
+    public virtual int Compare(T? x, T? y)
     {
-        return x.CompareTo(y);
+        return x switch
+        {
+            null when y is null => 0,
+            null => -1,
+            _ => y is null ? 1 : x.CompareTo(y)
+        };
     }
 
     /// <summary>
@@ -211,7 +216,7 @@ public abstract class SnapTypeBase<T> : SnapTypeBase, IComparable<T>, IEquatable
     /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <c>false</c>.
     /// </returns>
     /// <param name="other">An object to compare with this object.</param>
-    public virtual bool Equals(T other)
+    public virtual bool Equals(T? other)
     {
         return IsEqualTo(other);
     }

--- a/src/SnapDB/Snap/Storage/FileFlags.cs
+++ b/src/SnapDB/Snap/Storage/FileFlags.cs
@@ -88,6 +88,7 @@ public static class FileFlags
     /// </summary>
     public static readonly Guid Stage8 = new(0x69be577b, 0xc044, 0x49c2, 0x85, 0xb3, 0x8f, 0x8f, 0xad, 0x76, 0x38, 0x03);
 
+    // {B5A3FBC4-285A-4559-A3EA-0940219677F8}
     /// <summary>
     /// Indicates that the file is in Stage 9.
     /// </summary>
@@ -106,7 +107,7 @@ public static class FileFlags
     public static readonly Guid IntermediateFile = new(0xd4626375, 0x3e2f, 0x4a62, 0xbc, 0x12, 0x65, 0xbb, 0x45, 0xe4, 0xa7, 0xb6);
 
     /// <summary>
-    /// Gets the flag associated with the supplied stage
+    /// Gets the flag associated with the supplied stage.
     /// </summary>
     /// <param name="stageNumber">The stage number for which to retrieve the <see cref="Guid"/>.</param>
     /// <returns>
@@ -137,5 +138,67 @@ public static class FileFlags
         };
     }
 
+    /// <summary>
+    /// Gets the number of the supplied stage <paramref name="flag"/>.
+    /// </summary>
+    /// <param name="flag">Stage flag.</param>
+    /// <returns>Number of specified stage <paramref name="flag"/>; otherwise, -1 if flag is not a stage flag.</returns>
+    public static int GetStageNumber(Guid flag)
+    {
+        if (flag == Stage0)
+            return 0;
+        if (flag == Stage1)
+            return 1;
+        if (flag == Stage2)
+            return 2;
+        if (flag == Stage3)
+            return 3;
+        if (flag == Stage4)
+            return 4;
+        if (flag == Stage5)
+            return 5;
+        if (flag == Stage6)
+            return 6;
+        if (flag == Stage7)
+            return 7;
+        if (flag == Stage8)
+            return 8;
+        if (flag == Stage9)
+            return 9;
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Gets the stage number from the set of supplied file <paramref name="flags"/>.
+    /// </summary>
+    /// <param name="flag">File flags.</param>
+    /// <returns>Stage number from the set of supplied file <paramref name="flags"/>; otherwise, -1 if none of the flags is a stage flag.</returns>
+    public static int GetStageNumber(Guid[] flags)
+    {
+        foreach (Guid flag in flags)
+        {
+            int stage = GetStageNumber(flag);
+
+            if (stage > -1)
+                return stage;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Determines if the supplied flag is a stage flag.
+    /// </summary>
+    /// <param name="flag">Flag to test.</param>
+    /// <returns><c>true</c> if <paramref name="flag"/> is a stage flag; otherwise, <c>false</c>.</returns>
+    public static bool IsStageFlag(Guid flag)
+    {
+        return GetStageNumber(flag) > -1;
+
+    }
+
+
+
     #endregion
-}
+    }

--- a/src/SnapDB/SnapDB.csproj
+++ b/src/SnapDB/SnapDB.csproj
@@ -17,12 +17,12 @@
 
   <ItemGroup>
     <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
-    <PackageReference Include="Gemstone.Common" Version="1.0.100" />
-    <PackageReference Include="Gemstone.Communication" Version="1.0.100" />
+    <PackageReference Include="Gemstone.Common" Version="1.0.101" />
+    <PackageReference Include="Gemstone.Communication" Version="1.0.101" />
     <PackageReference Include="Gemstone.Diagnostics" Version="1.0.100" />
-    <PackageReference Include="Gemstone.IO" Version="1.0.100" />
-    <PackageReference Include="Gemstone.Numeric" Version="1.0.100" />
-    <PackageReference Include="Gemstone.Security" Version="1.0.100" />
+    <PackageReference Include="Gemstone.IO" Version="1.0.101" />
+    <PackageReference Include="Gemstone.Numeric" Version="1.0.101" />
+    <PackageReference Include="Gemstone.Security" Version="1.0.101" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
   </ItemGroup>
 

--- a/src/UnitTests/Security/SecureStream_Test.cs
+++ b/src/UnitTests/Security/SecureStream_Test.cs
@@ -98,7 +98,7 @@ public class SecureStreamTest
 
     //}
 
-    // TODO: Disabled [Test]
+    [Test]
     public void TestDefault()
     {
         Logger.Console.Verbose = VerboseLevel.All;
@@ -110,7 +110,7 @@ public class SecureStreamTest
         ThreadPool.QueueUserWorkItem(ClientDefault, net.ClientStream);
 
         // TODO: This should timeout to accomodate initialization failure
-        if (!sa.TryAuthenticateAsServer(net.ServerStream, true, out Stream stream, out T))
+        if (!sa.TryAuthenticateAsServer(net.ServerStream, false, out Stream stream, out T))
             throw new Exception();
 
         stream.Write("Message");
@@ -150,10 +150,9 @@ public class SecureStreamTest
         Thread.Sleep(100);
     }
 
-    // TODO: Disabled [Test]
+    [Test]
     public void TestBenchmarkIntegrated()
     {
-        return;
         Logger.Console.Verbose = VerboseLevel.All;
         m_sw.Reset();
 
@@ -161,19 +160,20 @@ public class SecureStreamTest
 
         SecureStreamServer<NullUserToken> sa = new();
         sa.AddUserIntegratedSecurity("Zthe\\steven", new NullUserToken());
+        //sa.AddUserIntegratedSecurity("GPA\\rcarroll", new NullUserToken());
         ThreadPool.QueueUserWorkItem(ClientBenchmarkIntegrated, net.ClientStream);
 
         Stream stream;
-        sa.TryAuthenticateAsServer(net.ServerStream, true, out stream, out T);
-        sa.TryAuthenticateAsServer(net.ServerStream, true, out stream, out T);
-        sa.TryAuthenticateAsServer(net.ServerStream, true, out stream, out T);
-        sa.TryAuthenticateAsServer(net.ServerStream, true, out stream, out T);
-        sa.TryAuthenticateAsServer(net.ServerStream, true, out stream, out T);
+        sa.TryAuthenticateAsServer(net.ServerStream, false, out stream, out T);
+        sa.TryAuthenticateAsServer(net.ServerStream, false, out stream, out T);
+        sa.TryAuthenticateAsServer(net.ServerStream, false, out stream, out T);
+        sa.TryAuthenticateAsServer(net.ServerStream, false, out stream, out T);
+        sa.TryAuthenticateAsServer(net.ServerStream, false, out stream, out T);
 
         Thread.Sleep(100);
     }
 
-    // TODO: Disabled [Test]
+    [Test]
     public void TestRepeatIntegrated()
     {
         for (int x = 0; x < 5; x++)

--- a/src/UnitTests/SnapDB.UnitTests.csproj
+++ b/src/UnitTests/SnapDB.UnitTests.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
-    <PackageReference Include="Gemstone.Common" Version="1.0.100" />
+    <PackageReference Include="Gemstone.Common" Version="1.0.101" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />


### PR DESCRIPTION
By applying a seek and/or match filter function to Snap sever settings, ACL's can be generically implemented by a host.

An addition user-defined function implemented by the host is used to check to write operations.