### PR TITLE
Generic socket custom-command seam, shared archive path/fill logic, and typed-value support

### DIFF
--- a/src/SnapDB/BitConvert.cs
+++ b/src/SnapDB/BitConvert.cs
@@ -24,8 +24,6 @@
 //
 //******************************************************************************************************
 
-using System.Diagnostics;
-
 namespace SnapDB;
 
 /// <summary>
@@ -47,7 +45,7 @@ public static class BitConvert
     /// This method performs an unsafe conversion by treating the input float as an uint and
     /// then casting it to ulong.
     /// </remarks>
-    /// <seealso cref="ToUInt64(float)"/>
+    /// <seealso cref="ToSingle(ulong)"/>
     public static unsafe ulong ToUInt64(float value)
     {
         return *(uint*)&value;
@@ -73,6 +71,38 @@ public static class BitConvert
     }
 
     /// <summary>
+    /// Converts a double-precision floating-point number to an unsigned 64-bit integer representation.
+    /// </summary>
+    /// <param name="value">The double-precision floating-point number to convert.</param>
+    /// <returns>
+    /// An unsigned 64-bit integer representation of the input double-precision floating-point number.
+    /// </returns>
+    /// <remarks>
+    /// This method performs an unsafe conversion by casting double to ulong.
+    /// </remarks>
+    /// <seealso cref="ToDouble(ulong)"/>
+    public static unsafe ulong ToUInt64(double value)
+    {
+        return *(ulong*)&value;
+    }
+
+    /// <summary>
+    /// Converts an unsigned 64-bit integer to a double-precision floating-point number.
+    /// </summary>
+    /// <param name="value">The unsigned 64-bit integer to convert.</param>
+    /// <returns>
+    /// A double-precision floating-point number representing the input unsigned 64-bit integer.
+    /// </returns>
+    /// <remarks>
+    /// This method performs an unsafe conversion by casting the input ulong as a double.
+    /// </remarks>
+    /// <seealso cref="ToUInt64(double)"/>
+    public static unsafe double ToDouble(ulong value)
+    {
+        return *(double*)&value;
+    }
+
+    /// <summary>
     /// Converts a Guid value into two unsigned 64-bit integers.
     /// </summary>
     /// <param name="value">Guid value to convert.</param>
@@ -86,7 +116,7 @@ public static class BitConvert
 
         ulong value1;
         ulong value2;
-        
+
         fixed (byte* ptr = bytes)
         {
             ulong* lptr = (ulong*)ptr;
@@ -94,7 +124,7 @@ public static class BitConvert
             lptr++;
             value2 = *lptr;
         }
-        
+
         return (value1, value2);
     }
 
@@ -120,6 +150,6 @@ public static class BitConvert
 
         return new Guid(bytes);
     }
-    
+
     #endregion
 }

--- a/src/SnapDB/Snap/Services/ArchiveDetails.cs
+++ b/src/SnapDB/Snap/Services/ArchiveDetails.cs
@@ -23,8 +23,6 @@
 //       Converted code to .NET core.
 //
 //******************************************************************************************************
-using System.Linq;
-
 
 namespace SnapDB.Snap.Services;
 

--- a/src/SnapDB/Snap/Services/ArchiveDirectoryFillMethod.cs
+++ b/src/SnapDB/Snap/Services/ArchiveDirectoryFillMethod.cs
@@ -1,0 +1,43 @@
+//******************************************************************************************************
+//  ArchiveDirectoryFillMethod.cs - Gbtc
+//
+//  Copyright © 2026, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  06/23/2026 - J. Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+namespace SnapDB.Snap.Services;
+
+/// <summary>
+/// Specifies how a write directory is selected from the set of configured archive directories when more than one
+/// is available.
+/// </summary>
+public enum ArchiveDirectoryFillMethod
+{
+    /// <summary>
+    /// Fill each configured write path, in order, advancing to the next only when the current path's drive lacks
+    /// sufficient free space. This is the default and matches the historical archive write behavior.
+    /// </summary>
+    Sequential,
+
+    /// <summary>
+    /// Distribute new files across the configured write paths in round-robin order, skipping any path whose drive
+    /// lacks sufficient free space.
+    /// </summary>
+    RoundRobin
+}

--- a/src/SnapDB/Snap/Services/Configuration/AdvancedServerDatabaseConfig.cs
+++ b/src/SnapDB/Snap/Services/Configuration/AdvancedServerDatabaseConfig.cs
@@ -79,6 +79,7 @@ public class AdvancedServerDatabaseConfig<TKey, TValue> : IToServerDatabaseSetti
         DesiredRemainingSpace = 5L * SI2.Giga;
         StagingCount = 3;
         DirectoryMethod = ArchiveDirectoryMethod.TopDirectoryOnly;
+        FillMethod = ArchiveDirectoryFillMethod.Sequential;
         DiskFlushInterval = 10000;
         CacheFlushInterval = 100;
     }
@@ -119,6 +120,12 @@ public class AdvancedServerDatabaseConfig<TKey, TValue> : IToServerDatabaseSetti
     /// top directory only.
     /// </summary>
     public ArchiveDirectoryMethod DirectoryMethod { get; set; }
+
+    /// <summary>
+    /// Gets or sets how a write path is selected from the final write paths when more than one is configured.
+    /// Defaults to <see cref="ArchiveDirectoryFillMethod.Sequential"/>.
+    /// </summary>
+    public ArchiveDirectoryFillMethod FillMethod { get; set; }
 
     /// <summary>
     /// The number of milliseconds before data is automatically flushed to the disk.
@@ -234,8 +241,12 @@ public class AdvancedServerDatabaseConfig<TKey, TValue> : IToServerDatabaseSetti
             if (remainingStages > 0)
                 rollover.ArchiveSettings.ConfigureOnDisk([m_mainPath], SI2.Giga, ArchiveDirectoryMethod.TopDirectoryOnly, ArchiveEncodingMethod, "stage" + stage, intermediateFilePendingExtension, intermediateFileFinalExtension, FileFlags.GetStage(stage), FileFlags.IntermediateFile);
             else
-                // Final staging file
+            {
+                // Final staging file - this is the only stage that writes across the configured final paths, so the
+                // fill method (sequential vs round-robin) applies here
                 rollover.ArchiveSettings.ConfigureOnDisk(finalPaths, DesiredRemainingSpace, DirectoryMethod, ArchiveEncodingMethod, DatabaseName.ToNonNullNorEmptyString("stage" + stage).RemoveInvalidFileNameCharacters(), finalFilePendingExtension, finalFileFinalExtension, FileFlags.GetStage(stage));
+                rollover.ArchiveSettings.FillMethod = FillMethod;
+            }
 
             rollover.ArchiveSettings.Metadata = Metadata;
 

--- a/src/SnapDB/Snap/Services/Net/CustomCommandNotSupportedException.cs
+++ b/src/SnapDB/Snap/Services/Net/CustomCommandNotSupportedException.cs
@@ -1,0 +1,50 @@
+//******************************************************************************************************
+//  CustomCommandNotSupportedException.cs - Gbtc
+//
+//  Copyright © 2026, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  06/23/2026 - J. Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+namespace SnapDB.Snap.Services.Net;
+
+/// <summary>
+/// Exception thrown when a client invokes a custom command that the server does not support, either because no
+/// handler is registered for the command name or because the server is an older version that does not recognize
+/// the custom-command protocol.
+/// </summary>
+/// <remarks>
+/// Callers can catch this exception to degrade gracefully when connecting to servers that lack support for a
+/// given custom command.
+/// </remarks>
+public class CustomCommandNotSupportedException : Exception
+{
+    /// <summary>
+    /// Gets the name of the custom command that was not supported, when known.
+    /// </summary>
+    public string? CommandName { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="CustomCommandNotSupportedException"/>.
+    /// </summary>
+    /// <param name="commandName">The name of the unsupported custom command, when known.</param>
+    public CustomCommandNotSupportedException(string? commandName) : base($"Custom command '{commandName}' is not supported by the server.")
+    {
+        CommandName = commandName;
+    }
+}

--- a/src/SnapDB/Snap/Services/Net/ServerCommand.cs
+++ b/src/SnapDB/Snap/Services/Net/ServerCommand.cs
@@ -66,7 +66,13 @@ public enum ServerCommand : byte
 
     /// <summary>
     /// </summary>
-    GetAllDatabases = 7
+    GetAllDatabases = 7,
+
+    /// <summary>
+    /// Invokes a named, server-registered custom command with an opaque request payload, returning an opaque
+    /// response payload. Provides a generic extension point without coupling the protocol to specific features.
+    /// </summary>
+    RunCustomCommand = 8
 }
 
 /// <summary>
@@ -184,7 +190,25 @@ public enum ServerResponse : byte
 
     /// <summary>
     /// </summary>
-    AuthenticationFailed
+    AuthenticationFailed,
+
+    /// <summary>
+    /// Returned by <see cref="ServerCommand.RunCustomCommand"/> when a registered handler produced a result. The
+    /// length-prefixed response payload follows.
+    /// </summary>
+    CustomCommandResult = 26,
+
+    /// <summary>
+    /// Returned by <see cref="ServerCommand.RunCustomCommand"/> when no handler is registered for the requested
+    /// command name. The connection remains usable.
+    /// </summary>
+    CustomCommandNotSupported = 27,
+
+    /// <summary>
+    /// Returned by <see cref="ServerCommand.RunCustomCommand"/> when a registered handler threw an exception. The
+    /// error message string follows. The connection remains usable.
+    /// </summary>
+    CustomCommandError = 28
 }
 
 #endregion

--- a/src/SnapDB/Snap/Services/Net/SnapStreamingClient.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapStreamingClient.cs
@@ -176,6 +176,54 @@ public class SnapStreamingClient : SnapClient
     }
 
     /// <summary>
+    /// Invokes a named, server-registered custom command at the connection root level.
+    /// </summary>
+    /// <param name="command">The case-insensitive name of the custom command to invoke.</param>
+    /// <param name="request">The opaque request payload; may be empty.</param>
+    /// <returns>The opaque response payload produced by the server-side handler.</returns>
+    /// <exception cref="CustomCommandNotSupportedException">
+    /// The server is an older version that does not recognize the custom-command protocol, or no handler is
+    /// registered for <paramref name="command"/>.
+    /// </exception>
+    public override byte[] RunCustomCommand(string command, byte[] request)
+    {
+        if (m_sortedTreeEngine is not null)
+            throw new InvalidOperationException("Cannot run a custom command while connected to a database; use a dedicated connection for custom commands.");
+
+        request ??= [];
+
+        m_stream.Write((byte)ServerCommand.RunCustomCommand);
+        m_stream.Write(command);
+        m_stream.Write(request.Length);
+
+        if (request.Length > 0)
+            m_stream.Write(request, 0, request.Length);
+
+        m_stream.Flush();
+
+        ServerResponse response = (ServerResponse)m_stream.ReadUInt8();
+
+        switch (response)
+        {
+            case ServerResponse.UnhandledException:
+                throw new Exception($"Server UnhandledException: \n{m_stream.ReadString()}");
+            case ServerResponse.CustomCommandResult:
+                int length = m_stream.ReadInt32();
+                return length > 0 ? m_stream.ReadBytes(length) : [];
+            case ServerResponse.CustomCommandNotSupported:
+                throw new CustomCommandNotSupportedException(m_stream.ReadString());
+            case ServerResponse.CustomCommandError:
+                throw new Exception($"Server custom command error: {m_stream.ReadString()}");
+            case ServerResponse.UnknownCommand:
+                // Older server that does not recognize the custom-command protocol; it echoes the command byte and drops the connection
+                m_stream.ReadUInt8();
+                throw new CustomCommandNotSupportedException(command);
+            default:
+                throw new Exception($"Unknown server response: {response}");
+        }
+    }
+
+    /// <summary>
     /// Creates a <see cref="SnapStreamingClient"/>
     /// </summary>
     /// <param name="stream">The config to use for the client</param>

--- a/src/SnapDB/Snap/Services/Net/SnapStreamingServer.cs
+++ b/src/SnapDB/Snap/Services/Net/SnapStreamingServer.cs
@@ -283,6 +283,37 @@ public class SnapStreamingServer : DisposableLoggingClassBase
                         return;
 
                     break;
+                case ServerCommand.RunCustomCommand:
+                    string customCommand = m_stream.ReadString();
+                    int requestLength = m_stream.ReadInt32();
+                    byte[] request = requestLength > 0 ? m_stream.ReadBytes(requestLength) : [];
+
+                    if (!m_server.TryGetCustomCommand(customCommand, out Func<byte[], byte[]>? handler) || handler is null)
+                    {
+                        m_stream.Write((byte)ServerResponse.CustomCommandNotSupported);
+                        m_stream.Write(customCommand);
+                        m_stream.Flush();
+                        break;
+                    }
+
+                    try
+                    {
+                        byte[] response = handler(request) ?? [];
+                        m_stream.Write((byte)ServerResponse.CustomCommandResult);
+                        m_stream.Write(response.Length);
+
+                        if (response.Length > 0)
+                            m_stream.Write(response, 0, response.Length);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Publish(MessageLevel.Warning, "Custom Command Error", $"Custom command '{customCommand}' handler threw an exception.", null, ex);
+                        m_stream.Write((byte)ServerResponse.CustomCommandError);
+                        m_stream.Write(ex.Message);
+                    }
+
+                    m_stream.Flush();
+                    break;
                 case ServerCommand.Disconnect:
                     m_stream.Write((byte)ServerResponse.GoodBye);
                     m_stream.Write("Good bye!");

--- a/src/SnapDB/Snap/Services/SnapClient.cs
+++ b/src/SnapDB/Snap/Services/SnapClient.cs
@@ -97,6 +97,26 @@ public abstract class SnapClient : DisposableLoggingClassBase
     /// </remarks>
     public abstract bool Contains(string databaseName);
 
+    /// <summary>
+    /// Invokes a named, server-registered custom command, passing an opaque request payload and returning an
+    /// opaque response payload.
+    /// </summary>
+    /// <param name="command">The case-insensitive name of the custom command to invoke.</param>
+    /// <param name="request">The opaque request payload; may be empty.</param>
+    /// <returns>The opaque response payload produced by the server-side handler.</returns>
+    /// <exception cref="Net.CustomCommandNotSupportedException">
+    /// The server does not support the custom-command protocol, or no handler is registered for
+    /// <paramref name="command"/>.
+    /// </exception>
+    /// <remarks>
+    /// Custom commands operate at the connection root level. When using a network client, do not invoke a custom
+    /// command while connected to a database; use a dedicated connection for custom commands.
+    /// </remarks>
+    public virtual byte[] RunCustomCommand(string command, byte[] request)
+    {
+        throw new NotSupportedException("This client does not support custom commands.");
+    }
+
     #endregion
 
     #region [ Static ]

--- a/src/SnapDB/Snap/Services/SnapServer.cs
+++ b/src/SnapDB/Snap/Services/SnapServer.cs
@@ -24,6 +24,7 @@
 //
 //******************************************************************************************************
 
+using System.Collections.Concurrent;
 using System.Net;
 using System.Text;
 using Gemstone.Diagnostics;
@@ -58,6 +59,12 @@ public partial class SnapServer : DisposableLoggingClassBase
     /// All of the socket listener per IPEndPoint.
     /// </summary>
     private readonly Dictionary<IPEndPoint, SnapSocketListener> m_sockets;
+
+    /// <summary>
+    /// Registered custom command handlers, keyed by case-insensitive command name. Each handler maps an opaque
+    /// request payload to an opaque response payload.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, Func<byte[], byte[]>> m_customCommands = new(StringComparer.OrdinalIgnoreCase);
 
     private readonly Lock m_syncRoot = new();
     private bool m_disposed;
@@ -110,6 +117,47 @@ public partial class SnapServer : DisposableLoggingClassBase
     #endregion
 
     #region [ Methods ]
+
+    /// <summary>
+    /// Registers a custom command handler that can be invoked by clients via
+    /// <see cref="SnapClient.RunCustomCommand"/>. Registering the same command name again replaces the prior handler.
+    /// </summary>
+    /// <param name="command">The case-insensitive command name.</param>
+    /// <param name="handler">
+    /// Handler mapping an opaque request payload to an opaque response payload. The handler runs on the connection's
+    /// thread; it should be thread-safe and reasonably fast.
+    /// </param>
+    public void RegisterCustomCommand(string command, Func<byte[], byte[]> handler)
+    {
+        if (string.IsNullOrEmpty(command))
+            throw new ArgumentNullException(nameof(command));
+
+        m_customCommands[command] = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    /// <summary>
+    /// Removes a previously registered custom command handler.
+    /// </summary>
+    /// <param name="command">The case-insensitive command name.</param>
+    /// <returns><c>true</c> if a handler was removed; otherwise, <c>false</c>.</returns>
+    public bool UnregisterCustomCommand(string command)
+    {
+        return command is not null && m_customCommands.TryRemove(command, out _);
+    }
+
+    /// <summary>
+    /// Attempts to get the registered handler for the specified custom command name.
+    /// </summary>
+    internal bool TryGetCustomCommand(string command, out Func<byte[], byte[]>? handler)
+    {
+        if (command is null)
+        {
+            handler = null;
+            return false;
+        }
+
+        return m_customCommands.TryGetValue(command, out handler);
+    }
 
     /// <summary>
     /// Releases the unmanaged resources used by the <see cref="SnapServer"/> object and optionally releases the managed resources.

--- a/src/SnapDB/Snap/Services/SnapServerClient.cs
+++ b/src/SnapDB/Snap/Services/SnapServerClient.cs
@@ -24,6 +24,8 @@
 //
 //******************************************************************************************************
 
+using SnapDB.Snap.Services.Net;
+
 namespace SnapDB.Snap.Services;
 
 public partial class SnapServer
@@ -142,6 +144,23 @@ public partial class SnapServer
             ObjectDisposedException.ThrowIf(m_disposed, this);
 
             return m_server.GetDatabaseInfo();
+        }
+
+        /// <summary>
+        /// Invokes a named, server-registered custom command directly against the in-process server.
+        /// </summary>
+        /// <param name="command">The case-insensitive name of the custom command to invoke.</param>
+        /// <param name="request">The opaque request payload; may be empty.</param>
+        /// <returns>The opaque response payload produced by the server-side handler.</returns>
+        /// <exception cref="CustomCommandNotSupportedException">No handler is registered for <paramref name="command"/>.</exception>
+        public override byte[] RunCustomCommand(string command, byte[] request)
+        {
+            ObjectDisposedException.ThrowIf(m_disposed, this);
+
+            if (!m_server.TryGetCustomCommand(command, out Func<byte[], byte[]>? handler) || handler is null)
+                throw new CustomCommandNotSupportedException(command);
+
+            return handler(request ?? []) ?? [];
         }
 
         /// <summary>

--- a/src/SnapDB/Snap/Services/Writer/ArchiveInitializer.cs
+++ b/src/SnapDB/Snap/Services/Writer/ArchiveInitializer.cs
@@ -24,7 +24,6 @@
 //
 //******************************************************************************************************
 
-using Gemstone.IO;
 using SnapDB.Snap.Storage;
 using SnapDB.Snap.Types;
 using SnapDB.Threading;
@@ -41,6 +40,7 @@ public class ArchiveInitializer<TKey, TValue> where TKey : SnapTypeBase<TKey>, n
     #region [ Members ]
 
     private readonly ReaderWriterLockEasy m_lock;
+    private int m_writePathSeed;
 
     #endregion
 
@@ -148,6 +148,10 @@ public class ArchiveInitializer<TKey, TValue> where TKey : SnapTypeBase<TKey>, n
     }
 
     /// <summary>
+    /// Selects a write path with enough free space, distributing selections across the configured write paths in
+    /// round-robin order. See <see cref="ArchivePathHelper.GetPathWithEnoughSpace"/>.
+    /// </summary>
+    /// <summary>
     /// Creates a new random file in one of the provided folders in a round robin fashion.
     /// </summary>
     /// <param name="path">The base path where the archive file will be created.</param>
@@ -183,43 +187,14 @@ public class ArchiveInitializer<TKey, TValue> where TKey : SnapTypeBase<TKey>, n
 
     private string GetPath(string rootPath, DateTime time)
     {
-        switch (Settings.DirectoryMethod)
-        {
-            case ArchiveDirectoryMethod.TopDirectoryOnly:
-                break;
-            case ArchiveDirectoryMethod.Year:
-                rootPath = Path.Combine(rootPath, time.Year.ToString());
-                break;
-            case ArchiveDirectoryMethod.YearMonth:
-                rootPath = Path.Combine(rootPath, time.Year + time.Month.ToString("00"));
-                break;
-            case ArchiveDirectoryMethod.YearThenMonth:
-                rootPath = Path.Combine(rootPath, time.Year.ToString() + '\\' + time.Month.ToString("00"));
-                break;
-        }
-
-        if (!Directory.Exists(rootPath))
-            Directory.CreateDirectory(rootPath);
-
-        return rootPath;
+        return ArchivePathHelper.GetPath(rootPath, time, Settings.DirectoryMethod);
     }
 
+    // Selects a write path with enough free space, distributing selections across the configured write paths in
+    // round-robin order via a per-instance interlocked seed.
     private string GetPathWithEnoughSpace(long estimatedSize)
     {
-        if (estimatedSize < 0)
-            return Settings.WritePath.FirstOrDefault() ?? throw new InvalidOperationException("No write path defined");
-
-        long remainingSpace = Settings.DesiredRemainingSpace;
-
-        foreach (string path in Settings.WritePath)
-        {
-            FilePath.GetAvailableFreeSpace(path, out long freeSpace, out _);
-
-            if (freeSpace - estimatedSize > remainingSpace)
-                return path;
-        }
-
-        throw new InvalidOperationException("Out of free space");
+        return ArchivePathHelper.GetPathWithEnoughSpace(Settings.WritePath, estimatedSize, Settings.DesiredRemainingSpace, Settings.FillMethod, Interlocked.Increment(ref m_writePathSeed) - 1);
     }
 
     #endregion

--- a/src/SnapDB/Snap/Services/Writer/ArchiveInitializerSettings.cs
+++ b/src/SnapDB/Snap/Services/Writer/ArchiveInitializerSettings.cs
@@ -40,6 +40,7 @@ public class ArchiveInitializerSettings : SettingsBase<ArchiveInitializerSetting
 
     private long m_desiredRemainingSpace;
     private ArchiveDirectoryMethod m_directoryMethod;
+    private ArchiveDirectoryFillMethod m_fillMethod;
     private EncodingDefinition m_encodingMethod;
     private string m_fileExtension;
     private bool m_isMemoryArchive;
@@ -95,6 +96,20 @@ public class ArchiveInitializerSettings : SettingsBase<ArchiveInitializerSetting
         {
             TestForEditable();
             m_directoryMethod = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the method used to select a write path when more than one is configured. Defaults to
+    /// <see cref="ArchiveDirectoryFillMethod.Sequential"/>.
+    /// </summary>
+    public ArchiveDirectoryFillMethod FillMethod
+    {
+        get => m_fillMethod;
+        set
+        {
+            TestForEditable();
+            m_fillMethod = value;
         }
     }
 
@@ -226,8 +241,9 @@ public class ArchiveInitializerSettings : SettingsBase<ArchiveInitializerSetting
     /// <param name="stream">The stream where the configuration data will be saved.</param>
     public override void Save(Stream stream)
     {
-        stream.Write((byte)1);
+        stream.Write((byte)2);
         stream.Write((int)m_directoryMethod);
+        stream.Write((int)m_fillMethod);
         stream.Write(m_isMemoryArchive);
         stream.Write(m_prefix);
         stream.Write(m_fileExtension);
@@ -256,7 +272,12 @@ public class ArchiveInitializerSettings : SettingsBase<ArchiveInitializerSetting
         switch (version)
         {
             case 1:
+            case 2:
                 m_directoryMethod = (ArchiveDirectoryMethod)stream.ReadInt32();
+
+                // Fill method was introduced in version 2; version 1 streams default to Sequential
+                m_fillMethod = version >= 2 ? (ArchiveDirectoryFillMethod)stream.ReadInt32() : ArchiveDirectoryFillMethod.Sequential;
+
                 m_isMemoryArchive = stream.ReadBoolean();
                 m_prefix = stream.ReadString();
                 m_fileExtension = stream.ReadString();
@@ -311,6 +332,7 @@ public class ArchiveInitializerSettings : SettingsBase<ArchiveInitializerSetting
     private void Initialize()
     {
         m_directoryMethod = ArchiveDirectoryMethod.TopDirectoryOnly;
+        m_fillMethod = ArchiveDirectoryFillMethod.Sequential;
         m_isMemoryArchive = false;
         m_prefix = string.Empty;
         m_fileExtension = ".d2i";

--- a/src/SnapDB/Snap/Services/Writer/ArchivePathHelper.cs
+++ b/src/SnapDB/Snap/Services/Writer/ArchivePathHelper.cs
@@ -1,0 +1,130 @@
+//******************************************************************************************************
+//  ArchivePathHelper.cs - Gbtc
+//
+//  Copyright © 2026, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  06/23/2026 - J. Ritchie Carroll
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using Gemstone.IO;
+
+namespace SnapDB.Snap.Services.Writer;
+
+/// <summary>
+/// Provides shared helpers for resolving archive file directories and selecting a write directory from a set of
+/// candidate paths based on available free space.
+/// </summary>
+/// <remarks>
+/// These helpers centralize the directory layout and disk-space-aware path selection rules used by the archive
+/// writers (e.g., <see cref="ArchiveInitializer{TKey,TValue}"/> and
+/// <see cref="SimplifiedArchiveInitializer{TKey,TValue}"/>) so that any other component needing to place files
+/// alongside the historian archive (<c>.d2</c>) files can follow identical rules.
+/// </remarks>
+public static class ArchivePathHelper
+{
+    /// <summary>
+    /// Gets the directory, relative to an archive root, in which files for the specified <paramref name="time"/>
+    /// are placed according to the given <paramref name="directoryMethod"/>.
+    /// </summary>
+    /// <param name="time">Timestamp used to derive the dated sub-directory.</param>
+    /// <param name="directoryMethod">Directory structure to follow.</param>
+    /// <returns>
+    /// The relative directory, or an empty string for <see cref="ArchiveDirectoryMethod.TopDirectoryOnly"/>. This
+    /// method performs no I/O.
+    /// </returns>
+    public static string GetRelativeDirectory(DateTime time, ArchiveDirectoryMethod directoryMethod)
+    {
+        return directoryMethod switch
+        {
+            ArchiveDirectoryMethod.Year => time.Year.ToString(),
+            ArchiveDirectoryMethod.YearMonth => time.Year + time.Month.ToString("00"),
+            ArchiveDirectoryMethod.YearThenMonth => Path.Combine(time.Year.ToString(), time.Month.ToString("00")),
+            _ => string.Empty // TopDirectoryOnly
+        };
+    }
+
+    /// <summary>
+    /// Resolves the full directory for the specified <paramref name="rootPath"/> and <paramref name="time"/>
+    /// according to the given <paramref name="directoryMethod"/>, creating the directory if it does not exist.
+    /// </summary>
+    /// <param name="rootPath">Root archive directory.</param>
+    /// <param name="time">Timestamp used to derive the dated sub-directory.</param>
+    /// <param name="directoryMethod">Directory structure to follow.</param>
+    /// <returns>The full (and existing) directory path.</returns>
+    public static string GetPath(string rootPath, DateTime time, ArchiveDirectoryMethod directoryMethod)
+    {
+        string relativeDirectory = GetRelativeDirectory(time, directoryMethod);
+        string path = relativeDirectory.Length == 0 ? rootPath : Path.Combine(rootPath, relativeDirectory);
+
+        if (!Directory.Exists(path))
+            Directory.CreateDirectory(path);
+
+        return path;
+    }
+
+    /// <summary>
+    /// Selects a write directory from <paramref name="paths"/> that has enough free space to store a file of the
+    /// estimated size while still leaving the desired remaining space, distributing selections across the
+    /// candidate paths in round-robin order.
+    /// </summary>
+    /// <param name="paths">Candidate write directories, in configured order. Must contain at least one entry.</param>
+    /// <param name="estimatedSize">
+    /// Estimated size, in bytes, of the file to be written. A negative value skips the free-space check.
+    /// </param>
+    /// <param name="desiredRemainingSpace">Minimum free space, in bytes, to leave on the target drive.</param>
+    /// <param name="fillMethod">
+    /// Determines how the starting candidate is chosen: <see cref="ArchiveDirectoryFillMethod.Sequential"/> always
+    /// starts at the first path (filling paths in order), while <see cref="ArchiveDirectoryFillMethod.RoundRobin"/>
+    /// rotates the starting candidate using <paramref name="roundRobinSeed"/>.
+    /// </param>
+    /// <param name="roundRobinSeed">
+    /// A value used to rotate the starting candidate when <paramref name="fillMethod"/> is
+    /// <see cref="ArchiveDirectoryFillMethod.RoundRobin"/>; ignored otherwise. Callers typically pass a per-instance
+    /// counter (e.g., an interlocked increment) so that each call advances the round-robin position.
+    /// </param>
+    /// <returns>The selected write directory.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="paths"/> is <c>null</c> or empty, or no path has sufficient free space.
+    /// </exception>
+    public static string GetPathWithEnoughSpace(IList<string> paths, long estimatedSize, long desiredRemainingSpace, ArchiveDirectoryFillMethod fillMethod, int roundRobinSeed)
+    {
+        if (paths is null || paths.Count == 0)
+            throw new InvalidOperationException("No write path defined");
+
+        int count = paths.Count;
+
+        // Sequential fill always starts at the first path; round-robin rotates the start using the seed
+        int start = fillMethod == ArchiveDirectoryFillMethod.RoundRobin ? ((roundRobinSeed % count) + count) % count : 0;
+
+        // No size estimate: return the selected path without a free-space check
+        if (estimatedSize < 0)
+            return paths[start];
+
+        // Scan all candidate paths once, beginning at the round-robin position and wrapping around, returning the
+        // first whose drive has enough free space to store the estimated file while leaving the desired remaining space
+        for (int offset = 0; offset < count; offset++)
+        {
+            string path = paths[(start + offset) % count];
+
+            if (FilePath.GetAvailableFreeSpace(path, out long freeSpace, out _) && freeSpace - estimatedSize > desiredRemainingSpace)
+                return path;
+        }
+
+        throw new InvalidOperationException("Out of free space");
+    }
+}

--- a/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializer.cs
+++ b/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializer.cs
@@ -24,7 +24,6 @@
 //
 //******************************************************************************************************
 
-using Gemstone.IO;
 using SnapDB.Snap.Storage;
 using SnapDB.Snap.Types;
 using SnapDB.Threading;
@@ -41,6 +40,7 @@ public class SimplifiedArchiveInitializer<TKey, TValue> where TKey : SnapTypeBas
     #region [ Members ]
 
     private readonly ReaderWriterLockEasy m_lock;
+    private int m_writePathSeed;
 
     #endregion
 
@@ -148,39 +148,14 @@ public class SimplifiedArchiveInitializer<TKey, TValue> where TKey : SnapTypeBas
 
     private string GetPath(string rootPath, DateTime time)
     {
-        switch (Settings.DirectoryMethod)
-        {
-            case ArchiveDirectoryMethod.TopDirectoryOnly:
-                break;
-            case ArchiveDirectoryMethod.Year:
-                rootPath = Path.Combine(rootPath, time.Year.ToString());
-                break;
-            case ArchiveDirectoryMethod.YearMonth:
-                rootPath = Path.Combine(rootPath, time.Year + time.Month.ToString("00"));
-                break;
-            case ArchiveDirectoryMethod.YearThenMonth:
-                rootPath = Path.Combine(rootPath, time.Year.ToString() + '\\' + time.Month.ToString("00"));
-                break;
-        }
-
-        if (!Directory.Exists(rootPath))
-            Directory.CreateDirectory(rootPath);
-        return rootPath;
+        return ArchivePathHelper.GetPath(rootPath, time, Settings.DirectoryMethod);
     }
 
+    // Selects a write path with enough free space using the configured fill method, distributing selections in
+    // round-robin order (when enabled) via a per-instance interlocked seed.
     private string GetPathWithEnoughSpace(long estimatedSize)
     {
-        if (estimatedSize < 0)
-            return Settings.WritePath.First();
-        long remainingSpace = Settings.DesiredRemainingSpace;
-        foreach (string path in Settings.WritePath)
-        {
-            FilePath.GetAvailableFreeSpace(path, out long freeSpace, out _);
-            if (freeSpace - estimatedSize > remainingSpace)
-                return path;
-        }
-
-        throw new Exception("Out of free space");
+        return ArchivePathHelper.GetPathWithEnoughSpace(Settings.WritePath, estimatedSize, Settings.DesiredRemainingSpace, Settings.FillMethod, Interlocked.Increment(ref m_writePathSeed) - 1);
     }
 
     #endregion

--- a/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializerSettings.cs
+++ b/src/SnapDB/Snap/Services/Writer/SimplifiedArchiveInitializerSettings.cs
@@ -40,6 +40,7 @@ public class SimplifiedArchiveInitializerSettings : SettingsBase<SimplifiedArchi
 
     private long m_desiredRemainingSpace;
     private ArchiveDirectoryMethod m_directoryMethod;
+    private ArchiveDirectoryFillMethod m_fillMethod;
     private EncodingDefinition m_encodingMethod;
     private string m_finalExtension;
     private string m_pendingExtension;
@@ -95,6 +96,20 @@ public class SimplifiedArchiveInitializerSettings : SettingsBase<SimplifiedArchi
         {
             TestForEditable();
             m_directoryMethod = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the method used to select a write path when more than one is configured. Defaults to
+    /// <see cref="ArchiveDirectoryFillMethod.Sequential"/>.
+    /// </summary>
+    public ArchiveDirectoryFillMethod FillMethod
+    {
+        get => m_fillMethod;
+        set
+        {
+            TestForEditable();
+            m_fillMethod = value;
         }
     }
 
@@ -212,8 +227,9 @@ public class SimplifiedArchiveInitializerSettings : SettingsBase<SimplifiedArchi
     /// <param name="stream">The stream to which the configuration will be saved.</param>
     public override void Save(Stream stream)
     {
-        stream.Write((byte)1);
+        stream.Write((byte)2);
         stream.Write((int)m_directoryMethod);
+        stream.Write((int)m_fillMethod);
         stream.Write(m_prefix);
         stream.Write(m_pendingExtension);
         stream.Write(m_finalExtension);
@@ -242,7 +258,12 @@ public class SimplifiedArchiveInitializerSettings : SettingsBase<SimplifiedArchi
         switch (version)
         {
             case 1:
+            case 2:
                 m_directoryMethod = (ArchiveDirectoryMethod)stream.ReadInt32();
+
+                // Fill method was introduced in version 2; version 1 streams default to Sequential
+                m_fillMethod = version >= 2 ? (ArchiveDirectoryFillMethod)stream.ReadInt32() : ArchiveDirectoryFillMethod.Sequential;
+
                 m_prefix = stream.ReadString();
                 m_pendingExtension = stream.ReadString();
                 m_finalExtension = stream.ReadString();
@@ -285,6 +306,7 @@ public class SimplifiedArchiveInitializerSettings : SettingsBase<SimplifiedArchi
     private void Initialize()
     {
         m_directoryMethod = ArchiveDirectoryMethod.TopDirectoryOnly;
+        m_fillMethod = ArchiveDirectoryFillMethod.Sequential;
         m_prefix = string.Empty;
         m_pendingExtension = ".~d2i";
         m_finalExtension = ".d2i";


### PR DESCRIPTION
## Summary

Three related, low-level capabilities that support openHistorian's day-sharded event-details feature (see Related PRs), all designed to be backward compatible:

1. A **generic socket "custom command" facility** (a reusable RPC passthrough).
2. **Shared archive directory/path selection logic** plus a configurable **fill method** (sequential vs. round-robin).
3. **Typed-value `BitConvert` helpers** used by openHistorian's typed `HistorianValue`.

SnapDB intentionally has no knowledge of "event details" — openHistorian plugs into the generic seam.

## 1. Generic socket custom-command facility

- New `ServerCommand.RunCustomCommand = 8` and `ServerResponse` values `CustomCommandResult` / `CustomCommandNotSupported` / `CustomCommandError`.
- `SnapServer.RegisterCustomCommand(name, Func<byte[],byte[]>)` / `UnregisterCustomCommand` / internal `TryGetCustomCommand` — a thread-safe handler registry.
- Server dispatch added to `SnapStreamingServer.ProcessRootLevelCommands` (root level, since handlers are process-scoped). A known command with no registered handler responds `CustomCommandNotSupported` **without dropping the connection**.
- `SnapClient.RunCustomCommand(name, request)` — `virtual` on the base, overridden by `SnapStreamingClient` (over the socket; throws if used while connected to a database) and the in-process `SnapServer.Client` (direct invoke).
- New `CustomCommandNotSupportedException` so callers can detect and degrade gracefully.

**Backward compatibility**
- The Read/Write wire formats are unchanged.
- Old client → new server: old clients never send command 8; all existing commands behave identically.
- New client → old server: the old server hits its `default` case, returns `UnknownCommand`, and drops that connection. The client surfaces this as `CustomCommandNotSupportedException`, so callers can degrade. (Use a dedicated connection for custom commands so a drop never disrupts data reads — openHistorian's client does this.)
- There is no feature-negotiation handshake, so capability is discovered by attempting the command and catching the exception.

## 2. Shared archive path/fill logic + configurable fill method

- New `ArchivePathHelper` consolidates directory-layout and write-path selection logic that was **duplicated** across `ArchiveInitializer` and `SimplifiedArchiveInitializer`:
  - `GetRelativeDirectory(time, method)` — dated sub-path (pure).
  - `GetPath(root, time, method)` — combine + create.
  - `GetPathWithEnoughSpace(paths, estimatedSize, desiredRemainingSpace, fillMethod, seed)` — disk-space-aware selection.
- New `ArchiveDirectoryFillMethod { Sequential, RoundRobin }`, plumbed through `ArchiveInitializerSettings.FillMethod`, `SimplifiedArchiveInitializerSettings.FillMethod`, and `AdvancedServerDatabaseConfig.FillMethod`.
- The `YearThenMonth` layout now uses `Path.Combine` instead of a literal `\` separator (cross-platform; identical output on Windows).

**Reviewer / tester considerations**
- **Round-robin is opt-in. The default is `Sequential`, which preserves the historical first-fill behavior** (fill the first write directory until it lacks space, then advance). The previous code's comment claimed round-robin but actually behaved as sequential first-fill; behavior is unchanged unless `FillMethod = RoundRobin` is configured.
- The fill method is selected end-to-end from openHistorian's `DirectoryFillMethod` connection-string parameter (see openHistorian PR). Multi-drive deployments should verify expected file distribution after choosing a mode.
- **Settings serialization bumped to version 2**: `ArchiveInitializerSettings`/`SimplifiedArchiveInitializerSettings` now write a fill-method field. A v2-aware build reads old v1 streams (defaulting to `Sequential`); older builds cannot read v2 streams. Relevant only where these settings are persisted/transferred across mixed versions.

## 3. Typed-value BitConvert helpers

- `BitConvert.ToDouble(ulong)` and `BitConvert.ToUInt64(double)` added to support openHistorian's typed `HistorianValue` (64-bit value encodings).

## Reviewer / tester considerations (overall)

- No behavior change unless (a) a custom-command handler is registered (openHistorian registers `"GetEventDetails"`), or (b) `FillMethod = RoundRobin` is configured.
- **Publish ordering**: openHistorian's non-`Development` builds consume these via the `Gemstone.SnapDB` package, so this must be published before those builds pick up the feature.

## Testing

The custom-command path (client ⇄ server framing, registry, graceful degradation) is exercised end-to-end by openHistorian's `EventDetailsSocketTests`, including a live TCP round-trip through `SnapStreamingClient`/`SnapStreamingServer`.

## Related PRs

This change is part of an event-details feature spanning three repositories:
- Gemstone.Timeseries: https://github.com/gemstone/timeseries/pull/62
- openHistorian: https://github.com/snapdb/openHistorian/pull/159
